### PR TITLE
File path change for attachments upload

### DIFF
--- a/src/main/java/com/zain/almksazain/controller/APIController.java
+++ b/src/main/java/com/zain/almksazain/controller/APIController.java
@@ -1041,7 +1041,8 @@ public class APIController {
         String poNumber = firstRecord.getString("poNumber");
         List<String> allowedExtensions = Arrays.asList(".pdf", ".doc", ".csv", ".docx", ".xlsx", ".jpeg", ".msg", ".jpg", ".png", ".xlsm", ".xls", ".zip", ".rar");
 
-        String uploadDir = "/home/app/logs/ALM/POUPL/";
+//        String uploadDir = "/home/app/logs/ALM/POUPL/";
+        String uploadDir = "/data/app/logs/ALM/POUPL";
         List<String> InvalidItems = new ArrayList<>();
 
         long maxFileSize = 100 * 1024 * 1024;

--- a/src/main/java/com/zain/almksazain/controller/APIController.java
+++ b/src/main/java/com/zain/almksazain/controller/APIController.java
@@ -1042,7 +1042,7 @@ public class APIController {
         List<String> allowedExtensions = Arrays.asList(".pdf", ".doc", ".csv", ".docx", ".xlsx", ".jpeg", ".msg", ".jpg", ".png", ".xlsm", ".xls", ".zip", ".rar");
 
 //        String uploadDir = "/home/app/logs/ALM/POUPL/";
-        String uploadDir = "/data/app/logs/ALM/POUPL";
+        String uploadDir = "/data/app/logs/ALM/POUPL/";
         List<String> InvalidItems = new ArrayList<>();
 
         long maxFileSize = 100 * 1024 * 1024;


### PR DESCRIPTION
# Update Attachments Path from `/home` to `/data`

**Description:**
We updated the attachments path configuration to move storage from the shrinking root path (`/home`) to the data path (`/data`).

**Changes made:**

* Updated application code:

  ```java
  // String uploadDir = "/home/app/logs/ALM/POUPL/";
     String uploadDir = "/data/app/logs/ALM/POUPL";
  ```
* Updated database records:

  ```sql
  UPDATE tb_fileRecords
  SET filePath = REPLACE(filePath, '/home/app/logs/ALM/POUPL', '/data/app/logs/ALM/POUPL')
  WHERE filePath LIKE '/home/app/logs/ALM/POUPL%';
  ```
* Server configuration updates in **Tomcat** and **Nginx** to point to `/data`.
* Migrated files from `/home/app/logs/ALM/POUPL` → `/data/app/logs/ALM/POUPL`.

**Verification:**

* Attachments download tested successfully from ALM after migration. ✅


