### PR TITLE
Add DCC PO filter endpoint with synchronous execution

### DIFF
--- a/src/main/java/com/zain/almksazain/controller/DccPOController.java
+++ b/src/main/java/com/zain/almksazain/controller/DccPOController.java
@@ -8,10 +8,7 @@ import com.zain.almksazain.DTO.DccPOParentDTO;
 import com.zain.almksazain.DTO.DccPOResponseDTO;
 import com.zain.almksazain.DTO.DccPORequestDTO;
 import com.zain.almksazain.exception.DccPOProcessingException;
-import com.zain.almksazain.serviceImplementors.DccPOExportService;
-import com.zain.almksazain.serviceImplementors.DccPOService;
-import com.zain.almksazain.serviceImplementors.DccPOApproverService;
-import com.zain.almksazain.serviceImplementors.DccPOServiceV2;
+import com.zain.almksazain.serviceImplementors.*;
 import com.zain.almksazain.serviceImplementors.DccPOService.DccPOFetchResult;
 import com.zain.almksazain.serviceImplementors.DccPOServiceV2.DccPOFetchResultV2;
 import org.apache.logging.log4j.LogManager;
@@ -35,6 +32,8 @@ import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -62,6 +61,8 @@ public class DccPOController {
     @Autowired
     private DccPOServiceV2 dccPOServiceV2;
 
+    @Autowired
+    private DccPOApproverExportService dccPOApproverExportService;
     /**
      * Endpoint to retrieve paginated DCC PO Combined View data.
      * Accepts a request body with supplierId, pendingApprovers, pagination parameters, and optional search filters.
@@ -998,4 +999,216 @@ public DeferredResult<ResponseEntity<byte[]>> exportDccPOCombinedViewToExcelV2(@
 
     return deferredResult;
 }
+    @PostMapping(value = "/export-combined-view-approvers", produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+    public DeferredResult<ResponseEntity<byte[]>> exportDccPOCombinedViewApproversToExcel(@RequestBody DccPORequestDTO request) {
+        DeferredResult<ResponseEntity<byte[]>> deferredResult = new DeferredResult<>(120000L); // 2 minutes timeout
+
+        // Validate approverId is provided
+        if (request.getPendingApprovers() == null || request.getPendingApprovers().isEmpty()) {
+            deferredResult.setErrorResult(ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body("Approver ID is required".getBytes()));
+            return deferredResult;
+        }
+
+        logger.info("Starting approver export for approver ID: {} (showing only actioned records)", request.getPendingApprovers());
+
+        CompletableFuture<List<DccPOCombinedViewDTO>> future = dccPOApproverExportService.getAllDccPOForApproverExport(
+                request.getSupplierId(),
+                request.getPendingApprovers(),
+                request.getColumnName(),
+                request.getSearchQuery(),
+                request.getOperator());
+
+        future.thenAccept(data -> {
+            try {
+                if (data.isEmpty()) {
+                    logger.warn("No data found for approver export with ID: {}", request.getPendingApprovers());
+                    deferredResult.setErrorResult(ResponseEntity.status(HttpStatus.NO_CONTENT)
+                            .body("No data found for the specified approver".getBytes()));
+                    return;
+                }
+
+                logger.info("Processing {} total records for approver export", data.size());
+
+                // Sort the entire data list descending by Approval Count, then DccRecordNo, then LineNumber
+                data.sort(Comparator.comparing(DccPOCombinedViewDTO::getApprovalCount, Comparator.reverseOrder())
+                        .thenComparing(DccPOCombinedViewDTO::getDccRecordNo, Comparator.reverseOrder())
+                        .thenComparing(DccPOCombinedViewDTO::getLineNumber, Comparator.reverseOrder()));
+
+                // Group by dccRecordNo AFTER sorting to maintain order
+                Map<Long, List<DccPOCombinedViewDTO>> groupedByDccRecordNo = data.stream()
+                        .collect(Collectors.groupingBy(DccPOCombinedViewDTO::getDccRecordNo, LinkedHashMap::new, Collectors.toList()));
+
+                logger.info("Grouped into {} unique DCC records", groupedByDccRecordNo.size());
+
+                // Create Excel workbook with streaming for large data
+                SXSSFWorkbook workbook = new SXSSFWorkbook(100);
+                Sheet sheet = workbook.createSheet("DCC PO Approver Data");
+
+                CreationHelper createHelper = workbook.getCreationHelper();
+
+                // Date formatter for parsing strings (matches DTO format: "d-MMM-yyyy")
+                SimpleDateFormat dateFormatter = new SimpleDateFormat("d-MMM-yyyy", Locale.ENGLISH);
+
+                // Cell styles
+                CellStyle dateOnlyStyle = workbook.createCellStyle();
+                dateOnlyStyle.setDataFormat(createHelper.createDataFormat().getFormat("dd-MM-yyyy"));
+
+                CellStyle headerStyle = workbook.createCellStyle();
+                Font headerFont = workbook.createFont();
+                headerFont.setBold(true);
+                headerFont.setColor(IndexedColors.BLACK.getIndex());
+                headerStyle.setFont(headerFont);
+
+                // Create header row
+                Row headerRow = sheet.createRow(0);
+                String[] columnHeaders = {
+                        "Request No", "PO Number", "Project Name", "Acceptance Type", "Status", "Created Date", "Approval Date",
+                        "Vendor", "Created By", "Approval Count", "Pending Approvers", "User Aging", "Total Aging", "Vendor Comment",
+                        "Last Approver Comment", "PO Line Number", "UPL Line Number", "Serial Number", "PO Item Code", "Actual Item Code",
+                        "UPL Item Code", "PO Acceptance Qty", "PO Line Description", "UPL Line Description", "PO Pending Qty",
+                        "Acceptance Qty", "Location", "Scope of Work", "In Service Date", "Link ID", "TAG Number", "Remarks"
+                };
+
+                for (int i = 0; i < columnHeaders.length; i++) {
+                    Cell cell = headerRow.createCell(i);
+                    cell.setCellValue(columnHeaders[i]);
+                    cell.setCellStyle(headerStyle);
+                }
+
+                // Populate data rows
+                int rowNum = 1;
+                int totalRowsWritten = 0;
+
+                for (Map.Entry<Long, List<DccPOCombinedViewDTO>> entry : groupedByDccRecordNo.entrySet()) {
+                    DccPOCombinedViewDTO firstRecord = entry.getValue().get(0);
+
+                    for (DccPOCombinedViewDTO dto : entry.getValue()) {
+                        Row row = sheet.createRow(rowNum++);
+                        int col = 0;
+
+                        // Parent fields from firstRecord (these are consistent across all line items in a DCC)
+                        row.createCell(col++).setCellValue(firstRecord.getDccRecordNo() != null ? firstRecord.getDccRecordNo().toString() : "");
+                        row.createCell(col++).setCellValue(firstRecord.getDccPoNumber() != null ? firstRecord.getDccPoNumber() : "");
+
+                        // CRITICAL: Use the correct project name (newProjectName with fallback)
+                        row.createCell(col++).setCellValue(firstRecord.getProjectName() != null ? firstRecord.getProjectName() : "");
+
+                        row.createCell(col++).setCellValue(firstRecord.getDccAcceptanceType() != null ? firstRecord.getDccAcceptanceType() : "");
+                        row.createCell(col++).setCellValue(firstRecord.getDccStatus() != null ? firstRecord.getDccStatus() : "");
+
+                        // Created Date
+                        Cell createdDateCell = row.createCell(col++);
+                        String dccCreatedDateStr = firstRecord.getDccCreatedDate();
+                        if (dccCreatedDateStr != null && !dccCreatedDateStr.isEmpty()) {
+                            try {
+                                Date dccCreatedDate = dateFormatter.parse(dccCreatedDateStr);
+                                createdDateCell.setCellValue(dccCreatedDate);
+                                createdDateCell.setCellStyle(dateOnlyStyle);
+                            } catch (ParseException e) {
+                                logger.warn("Failed to parse Created Date '{}': {}", dccCreatedDateStr, e.getMessage());
+                                createdDateCell.setCellValue(dccCreatedDateStr);
+                            }
+                        } else {
+                            createdDateCell.setCellValue("");
+                        }
+
+                        // Approval Date
+                        Cell dateApprovedCell = row.createCell(col++);
+                        String dateApprovedStr = firstRecord.getDateApproved();
+                        if (dateApprovedStr != null && !dateApprovedStr.isEmpty()) {
+                            try {
+                                Date dateApproved = dateFormatter.parse(dateApprovedStr);
+                                dateApprovedCell.setCellValue(dateApproved);
+                                dateApprovedCell.setCellStyle(dateOnlyStyle);
+                            } catch (ParseException e) {
+                                logger.warn("Failed to parse Date Approved '{}': {}", dateApprovedStr, e.getMessage());
+                                dateApprovedCell.setCellValue(dateApprovedStr);
+                            }
+                        } else {
+                            dateApprovedCell.setCellValue("");
+                        }
+
+                        row.createCell(col++).setCellValue(firstRecord.getVendorName() != null ? firstRecord.getVendorName() : "");
+                        row.createCell(col++).setCellValue(firstRecord.getCreatedBy() != null ? firstRecord.getCreatedBy() : "");
+                        row.createCell(col++).setCellValue(firstRecord.getApprovalCount() != null ? firstRecord.getApprovalCount() : 0);
+                        row.createCell(col++).setCellValue(firstRecord.getPendingApprovers() != null ? firstRecord.getPendingApprovers() : "");
+                        row.createCell(col++).setCellValue(firstRecord.getUserAging() != null ? firstRecord.getUserAging() : "0 days 0 hrs 0 mins");
+                        row.createCell(col++).setCellValue(firstRecord.getTotalAging() != null ? firstRecord.getTotalAging() : "0 days 0 hrs 0 mins");
+                        row.createCell(col++).setCellValue(firstRecord.getVendorComment() != null ? firstRecord.getVendorComment() : "");
+                        row.createCell(col++).setCellValue(firstRecord.getApproverComment() != null ? firstRecord.getApproverComment() : "");
+
+                        // Line item fields from dto (these vary per line item)
+                        row.createCell(col++).setCellValue(dto.getLineNumber() != null ? dto.getLineNumber() : "");
+                        row.createCell(col++).setCellValue(dto.getUplLineNumber() != null ? dto.getUplLineNumber() : "");
+                        row.createCell(col++).setCellValue(dto.getLnProductSerialNo() != null ? dto.getLnProductSerialNo() : "");
+                        row.createCell(col++).setCellValue(dto.getItemPartNumber() != null ? dto.getItemPartNumber() : "");
+                        row.createCell(col++).setCellValue(dto.getActualItemCode() != null ? dto.getActualItemCode() : "");
+                        row.createCell(col++).setCellValue(dto.getUplLineItemCode() != null ? dto.getUplLineItemCode() : "");
+                        row.createCell(col++).setCellValue(dto.getpoAcceptanceQty() != null ? dto.getpoAcceptanceQty() : 0);
+                        row.createCell(col++).setCellValue(dto.getPoLineDescription() != null ? dto.getPoLineDescription() : "");
+                        row.createCell(col++).setCellValue(dto.getUplLineDescription() != null ? dto.getUplLineDescription() : "");
+                        row.createCell(col++).setCellValue(dto.getPoPendingQuantity() != null ? dto.getPoPendingQuantity() : 0.0);
+                        row.createCell(col++).setCellValue(dto.getPoOrderQuantity() != null ? dto.getPoOrderQuantity() : 0.0);
+                        row.createCell(col++).setCellValue(dto.getLnLocationName() != null ? dto.getLnLocationName() : "");
+                        row.createCell(col++).setCellValue(dto.getLnScopeOfWork() != null ? dto.getLnScopeOfWork() : "");
+
+                        // In-Service Date
+                        Cell inserviceDateCell = row.createCell(col++);
+                        String inserviceDateStr = dto.getLnInserviceDate();
+                        if (inserviceDateStr != null && !inserviceDateStr.isEmpty()) {
+                            try {
+                                Date inserviceDate = dateFormatter.parse(inserviceDateStr);
+                                inserviceDateCell.setCellValue(inserviceDate);
+                                inserviceDateCell.setCellStyle(dateOnlyStyle);
+                            } catch (ParseException e) {
+                                logger.warn("Failed to parse In-Service Date '{}': {}", inserviceDateStr, e.getMessage());
+                                inserviceDateCell.setCellValue(inserviceDateStr);
+                            }
+                        } else {
+                            inserviceDateCell.setCellValue("");
+                        }
+
+                        row.createCell(col++).setCellValue(dto.getLinkId() != null ? String.valueOf(dto.getLinkId()) : "");
+                        row.createCell(col++).setCellValue(dto.getTagNumber() != null ? dto.getTagNumber() : "");
+                        row.createCell(col++).setCellValue(dto.getLnRemarks() != null ? dto.getLnRemarks() : "");
+
+                        totalRowsWritten++;
+                    }
+                }
+
+                logger.info("Finished writing {} rows to Excel", totalRowsWritten);
+
+                // Write to byte array
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                workbook.write(baos);
+                workbook.dispose();
+                workbook.close();
+
+                // Set response headers and return
+                HttpHeaders responseHeaders = new HttpHeaders();
+                String filename = String.format("dcc_po_approver_export_%s_%s.xlsx",
+                        request.getPendingApprovers(),
+                        LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")));
+                responseHeaders.add("Content-Disposition", "attachment; filename=" + filename);
+
+                deferredResult.setResult(new ResponseEntity<>(baos.toByteArray(), responseHeaders, HttpStatus.OK));
+
+                logger.info("Successfully exported Excel file for approver {} with {} unique DCC records and {} total rows",
+                        request.getPendingApprovers(), groupedByDccRecordNo.size(), totalRowsWritten);
+
+            } catch (Exception ex) {
+                logger.error("Error generating Excel file for approver export", ex);
+                deferredResult.setErrorResult(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                        .body(("Error generating Excel for approver: " + ex.getMessage()).getBytes()));
+            }
+        }).exceptionally(throwable -> {
+            logger.error("Error processing DCC PO approver export request", throwable);
+            deferredResult.setErrorResult(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(("Error: " + (throwable.getCause() != null ? throwable.getCause().getMessage() : throwable.getMessage())).getBytes()));
+            return null;
+        });
+
+        return deferredResult;
+    }
 }

--- a/src/main/java/com/zain/almksazain/controller/DccPOController.java
+++ b/src/main/java/com/zain/almksazain/controller/DccPOController.java
@@ -848,7 +848,12 @@ public class DccPOController {
             if (filters.containsKey("createdByName") && !filters.get("createdByName").toString().trim().isEmpty()) {
                 fieldFilters.put("createdByName", filters.get("createdByName").toString().trim());
             }
-            // ADDED: Support "createdBy" as well
+
+            if (filters.containsKey("supplierId") && !filters.get("supplierId").toString().trim().isEmpty()
+                    && !filters.get("supplierId").toString().trim().equals("0")) {
+                fieldFilters.put("supplierId", filters.get("supplierId").toString().trim());
+            }
+
             if (filters.containsKey("createdBy") && !filters.get("createdBy").toString().trim().isEmpty()) {
                 fieldFilters.put("createdByName", filters.get("createdBy").toString().trim());
             }
@@ -964,6 +969,12 @@ public class DccPOController {
                                 case "createdByName":
                                     if (dto.getCreatedByName() == null ||
                                             !dto.getCreatedByName().toLowerCase().equals(value)) {
+                                        return false;
+                                    }
+                                    break;
+                                case "supplierId":
+                                    if (dto.getSupplierId() == null ||
+                                            !dto.getSupplierId().toLowerCase().equals(value)) {
                                         return false;
                                     }
                                     break;

--- a/src/main/java/com/zain/almksazain/controller/DccPOController.java
+++ b/src/main/java/com/zain/almksazain/controller/DccPOController.java
@@ -819,7 +819,7 @@ public class DccPOController {
             // Additional filters for specific fields
             Map<String, String> fieldFilters = new HashMap<>();
 
-            // String filters (exact match - case insensitive)
+            // String filters (exact match - case-insensitive)
             if (filters.containsKey("dccPoNumber") && !filters.get("dccPoNumber").toString().trim().isEmpty()) {
                 fieldFilters.put("dccPoNumber", filters.get("dccPoNumber").toString().trim());
             }
@@ -847,8 +847,22 @@ public class DccPOController {
             if (filters.containsKey("createdByName") && !filters.get("createdByName").toString().trim().isEmpty()) {
                 fieldFilters.put("createdByName", filters.get("createdByName").toString().trim());
             }
+            // ADDED: Support "createdBy" as well
+            if (filters.containsKey("createdBy") && !filters.get("createdBy").toString().trim().isEmpty()) {
+                fieldFilters.put("createdByName", filters.get("createdBy").toString().trim());
+            }
 
             // Integer filters
+
+            // Support "recordNo" (from response) AND "dccRecordNo" (internal)
+            if (filters.containsKey("recordNo") && !filters.get("recordNo").toString().trim().isEmpty()) {
+                try {
+                    fieldFilters.put("dccRecordNo", filters.get("recordNo").toString().trim());
+                } catch (NumberFormatException e) {
+                    logger.warn("Invalid recordNo format: {}", filters.get("recordNo"));
+                }
+            }
+
             if (filters.containsKey("dccRecordNo") && !filters.get("dccRecordNo").toString().trim().isEmpty()) {
                 try {
                     fieldFilters.put("dccRecordNo", filters.get("dccRecordNo").toString().trim());

--- a/src/main/java/com/zain/almksazain/controller/DccPOController.java
+++ b/src/main/java/com/zain/almksazain/controller/DccPOController.java
@@ -38,6 +38,7 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 /**
@@ -787,6 +788,291 @@ public class DccPOController {
 //
 //        return deferredResult;
 //    }
+
+    @PostMapping(value = "/filter", produces = MediaType.APPLICATION_JSON_VALUE)
+    @CrossOrigin(origins = "*", allowedHeaders = "*", maxAge = 3600)
+    public ResponseEntity<Map<String, Object>> filterDccPOCombinedView(
+            @RequestBody Map<String, Object> filters,
+            @RequestParam(defaultValue = "1") int page,  // Changed default to 1
+            @RequestParam(defaultValue = "100") int size,
+            @RequestParam(defaultValue = "dccRecordNo") String sortBy,
+            @RequestParam(defaultValue = "desc") String sortDir) {
+        try {
+            logger.info("DCC PO Filter request received with {} filters", filters.size());
+
+            // Extract filter parameters
+            String supplierId = filters.containsKey("supplierId") ?
+                    filters.get("supplierId").toString().trim() : "0";
+
+            String pendingApprovers = filters.containsKey("pendingApprovers") ?
+                    filters.get("pendingApprovers").toString().trim() : "";
+
+            String columnName = filters.containsKey("columnName") ?
+                    filters.get("columnName").toString().trim() : "";
+
+            String searchQuery = filters.containsKey("searchQuery") ?
+                    filters.get("searchQuery").toString().trim() : "";
+
+            String operator = filters.containsKey("operator") ?
+                    filters.get("operator").toString().trim() : "AND";
+
+            // Additional filters for specific fields
+            Map<String, String> fieldFilters = new HashMap<>();
+
+            // String filters (exact match - case insensitive)
+            if (filters.containsKey("dccPoNumber") && !filters.get("dccPoNumber").toString().trim().isEmpty()) {
+                fieldFilters.put("dccPoNumber", filters.get("dccPoNumber").toString().trim());
+            }
+
+            if (filters.containsKey("newProjectName") && !filters.get("newProjectName").toString().trim().isEmpty()) {
+                fieldFilters.put("newProjectName", filters.get("newProjectName").toString().trim());
+            }
+
+            if (filters.containsKey("dccStatus") && !filters.get("dccStatus").toString().trim().isEmpty()) {
+                fieldFilters.put("dccStatus", filters.get("dccStatus").toString().trim());
+            }
+
+            if (filters.containsKey("dccAcceptanceType") && !filters.get("dccAcceptanceType").toString().trim().isEmpty()) {
+                fieldFilters.put("dccAcceptanceType", filters.get("dccAcceptanceType").toString().trim());
+            }
+
+            if (filters.containsKey("vendorName") && !filters.get("vendorName").toString().trim().isEmpty()) {
+                fieldFilters.put("vendorName", filters.get("vendorName").toString().trim());
+            }
+
+            if (filters.containsKey("vendorNumber") && !filters.get("vendorNumber").toString().trim().isEmpty()) {
+                fieldFilters.put("vendorNumber", filters.get("vendorNumber").toString().trim());
+            }
+
+            if (filters.containsKey("createdByName") && !filters.get("createdByName").toString().trim().isEmpty()) {
+                fieldFilters.put("createdByName", filters.get("createdByName").toString().trim());
+            }
+
+            // Integer filters
+            if (filters.containsKey("dccRecordNo") && !filters.get("dccRecordNo").toString().trim().isEmpty()) {
+                try {
+                    fieldFilters.put("dccRecordNo", filters.get("dccRecordNo").toString().trim());
+                } catch (NumberFormatException e) {
+                    logger.warn("Invalid dccRecordNo format: {}", filters.get("dccRecordNo"));
+                }
+            }
+
+            if (filters.containsKey("approvalCount") && !filters.get("approvalCount").toString().trim().isEmpty()) {
+                try {
+                    fieldFilters.put("approvalCount", filters.get("approvalCount").toString().trim());
+                } catch (NumberFormatException e) {
+                    logger.warn("Invalid approvalCount format: {}", filters.get("approvalCount"));
+                }
+            }
+
+            // Date range filters
+            String createdDateStart = filters.containsKey("createdDateStart") ?
+                    filters.get("createdDateStart").toString().trim() : "";
+            String createdDateEnd = filters.containsKey("createdDateEnd") ?
+                    filters.get("createdDateEnd").toString().trim() : "";
+            String approvedDateStart = filters.containsKey("approvedDateStart") ?
+                    filters.get("approvedDateStart").toString().trim() : "";
+            String approvedDateEnd = filters.containsKey("approvedDateEnd") ?
+                    filters.get("approvedDateEnd").toString().trim() : "";
+
+            // Validate and adjust page/size
+            page = Math.max(page, 1);
+            size = Math.max(size, 1);
+
+            // Call SYNCHRONOUS service method (no CompletableFuture)
+            DccPOFetchResult result = dccPOService.getDccPOCombinedViewSync(
+                    supplierId,
+                    pendingApprovers,
+                    page,
+                    size,
+                    columnName,
+                    searchQuery,
+                    false, // not exporting
+                    operator);
+
+            List<DccPOCombinedViewDTO> data = result.getData();
+            Long totalFilteredRecords = result.getTotalFilteredRecords();
+
+            // Apply additional filters in memory
+            SimpleDateFormat sdf = new SimpleDateFormat("d-MMM-yyyy", Locale.ENGLISH);
+
+            List<DccPOCombinedViewDTO> filteredData = data.stream()
+                    .filter(dto -> {
+                        // Apply field filters
+                        for (Map.Entry<String, String> entry : fieldFilters.entrySet()) {
+                            String field = entry.getKey();
+                            String value = entry.getValue().toLowerCase();
+
+                            switch (field) {
+                                case "dccRecordNo":
+                                    if (dto.getDccRecordNo() != null &&
+                                            !dto.getDccRecordNo().toString().equals(value)) {
+                                        return false;
+                                    }
+                                    break;
+                                case "dccPoNumber":
+                                    if (dto.getDccPoNumber() == null ||
+                                            !dto.getDccPoNumber().toLowerCase().equals(value)) {
+                                        return false;
+                                    }
+                                    break;
+                                case "newProjectName":
+                                    if (dto.getNewProjectName() == null ||
+                                            !dto.getNewProjectName().toLowerCase().equals(value)) {
+                                        return false;
+                                    }
+                                    break;
+                                case "dccStatus":
+                                    if (dto.getDccStatus() == null ||
+                                            !dto.getDccStatus().toLowerCase().equals(value)) {
+                                        return false;
+                                    }
+                                    break;
+                                case "dccAcceptanceType":
+                                    if (dto.getDccAcceptanceType() == null ||
+                                            !dto.getDccAcceptanceType().toLowerCase().equals(value)) {
+                                        return false;
+                                    }
+                                    break;
+                                case "vendorName":
+                                    if (dto.getVendorName() == null ||
+                                            !dto.getVendorName().toLowerCase().equals(value)) {
+                                        return false;
+                                    }
+                                    break;
+                                case "vendorNumber":
+                                    if (dto.getVendorNumber() == null ||
+                                            !dto.getVendorNumber().toLowerCase().equals(value)) {
+                                        return false;
+                                    }
+                                    break;
+                                case "createdByName":
+                                    if (dto.getCreatedByName() == null ||
+                                            !dto.getCreatedByName().toLowerCase().equals(value)) {
+                                        return false;
+                                    }
+                                    break;
+                                case "approvalCount":
+                                    if (dto.getApprovalCount() != null &&
+                                            !dto.getApprovalCount().toString().equals(value)) {
+                                        return false;
+                                    }
+                                    break;
+                            }
+                        }
+
+                        // Apply date range filters
+                        try {
+                            if (!createdDateStart.isEmpty() || !createdDateEnd.isEmpty()) {
+                                if (dto.getDccCreatedDate() != null) {
+                                    Date dccDate = sdf.parse(dto.getDccCreatedDate());
+                                    if (!createdDateStart.isEmpty()) {
+                                        Date startDate = sdf.parse(createdDateStart);
+                                        if (dccDate.before(startDate)) return false;
+                                    }
+                                    if (!createdDateEnd.isEmpty()) {
+                                        Date endDate = sdf.parse(createdDateEnd);
+                                        if (dccDate.after(endDate)) return false;
+                                    }
+                                }
+                            }
+
+                            if (!approvedDateStart.isEmpty() || !approvedDateEnd.isEmpty()) {
+                                if (dto.getDateApproved() != null) {
+                                    Date approvedDate = sdf.parse(dto.getDateApproved());
+                                    if (!approvedDateStart.isEmpty()) {
+                                        Date startDate = sdf.parse(approvedDateStart);
+                                        if (approvedDate.before(startDate)) return false;
+                                    }
+                                    if (!approvedDateEnd.isEmpty()) {
+                                        Date endDate = sdf.parse(approvedDateEnd);
+                                        if (approvedDate.after(endDate)) return false;
+                                    }
+                                }
+                            }
+                        } catch (ParseException e) {
+                            logger.warn("Error parsing dates for filtering", e);
+                        }
+
+                        return true;
+                    })
+                    .collect(Collectors.toList());
+
+            // Update total count after additional filtering
+            totalFilteredRecords = (long) filteredData.size();
+
+            // Group by dccRecordNo
+            Map<Long, List<DccPOCombinedViewDTO>> groupedByDccRecordNo = filteredData.stream()
+                    .collect(Collectors.groupingBy(DccPOCombinedViewDTO::getDccRecordNo));
+
+            // Transform into parent DTOs WITHOUT line items
+            List<DccPOParentDTO> parentDTOs = groupedByDccRecordNo.entrySet().stream()
+                    .map(entry -> {
+                        DccPOCombinedViewDTO firstRecord = entry.getValue().get(0);
+                        DccPOParentDTO parentDTO = new DccPOParentDTO();
+
+                        // Populate ONLY parent-level fields
+                        parentDTO.setRecordNo(firstRecord.getDccRecordNo());
+                        parentDTO.setDccPoNumber(firstRecord.getDccPoNumber());
+                        parentDTO.setNewProjectName(firstRecord.getNewProjectName());
+                        parentDTO.setDccAcceptanceType(firstRecord.getDccAcceptanceType());
+                        parentDTO.setDccStatus(firstRecord.getDccStatus());
+                        parentDTO.setDccCreatedDate(firstRecord.getDccCreatedDate());
+                        parentDTO.setDateApproved(firstRecord.getDateApproved());
+                        parentDTO.setVendorComment(firstRecord.getVendorComment());
+                        parentDTO.setDccId(firstRecord.getDccId());
+                        parentDTO.setPoId(firstRecord.getPoId());
+                        parentDTO.setProjectName(firstRecord.getProjectName());
+                        parentDTO.setSupplierId(firstRecord.getSupplierId());
+                        parentDTO.setVendorNumber(firstRecord.getVendorNumber());
+                        parentDTO.setVendorName(firstRecord.getVendorName());
+                        parentDTO.setCreatedBy(firstRecord.getCreatedBy());
+                        parentDTO.setCreatedByName(firstRecord.getCreatedByName());
+                        parentDTO.setApprovalCount(firstRecord.getApprovalCount());
+                        parentDTO.setPendingApprovers(firstRecord.getPendingApprovers());
+                        parentDTO.setApproverComment(firstRecord.getApproverComment());
+                        parentDTO.setUserAging(firstRecord.getUserAging());
+                        parentDTO.setTotalAging(firstRecord.getTotalAging());
+                        parentDTO.setVendorEmail(firstRecord.getDccVendorEmail());
+                        parentDTO.setDccCurrency(firstRecord.getDccCurrency());
+
+                        // DO NOT add line items for filter endpoint
+                        parentDTO.setLineItems(new ArrayList<>());
+
+                        return parentDTO;
+                    })
+                    .sorted((a, b) -> b.getRecordNo().compareTo(a.getRecordNo()))
+                    .collect(Collectors.toList());
+
+            // Build response
+            Map<String, Object> response = new HashMap<>();
+            response.put("reports", parentDTOs);
+            response.put("currentPage", page);
+            response.put("totalItems", totalFilteredRecords);
+            response.put("totalPages", (int) Math.ceil((double) totalFilteredRecords / size));
+            response.put("first", page == 1);
+            response.put("last", page * size >= totalFilteredRecords);
+            response.put("size", size);
+            response.put("sort", sortBy + "," + sortDir);
+
+            logger.info("Successfully filtered DCC PO data. {} parent records returned (page: {}, size: {})",
+                    parentDTOs.size(), page, size);
+
+            return new ResponseEntity<>(response, HttpStatus.OK);
+
+        } catch (Exception e) {
+            logger.error("Error filtering DCC PO Combined View", e);
+            String errorMessage = "Error filtering DCC PO data: " + e.getMessage();
+            if (e instanceof NumberFormatException) {
+                errorMessage = "Invalid number format in filter parameters";
+            }
+            return new ResponseEntity<>(
+                    Collections.singletonMap("message", errorMessage),
+                    HttpStatus.BAD_REQUEST
+            );
+        }
+    }
+
 @PostMapping(value = "/export-combined-view", produces = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
 public DeferredResult<ResponseEntity<byte[]>> exportDccPOCombinedViewToExcelV2(@RequestBody DccPORequestDTO request) {
     DeferredResult<ResponseEntity<byte[]>> deferredResult = new DeferredResult<>(120000L); // 2 minutes timeout for V2

--- a/src/main/java/com/zain/almksazain/serviceImplementors/DccPOApproverExportService.java
+++ b/src/main/java/com/zain/almksazain/serviceImplementors/DccPOApproverExportService.java
@@ -1,0 +1,599 @@
+package com.zain.almksazain.serviceImplementors;
+
+import com.zain.almksazain.DTO.DccPOCombinedViewDTO;
+import com.zain.almksazain.exception.DccPOProcessingException;
+import com.zain.almksazain.model.*;
+import com.zain.almksazain.repo.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.text.SimpleDateFormat;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+public class DccPOApproverExportService {
+
+    private static final Logger logger = LogManager.getLogger(DccPOApproverExportService.class);
+
+    @Autowired
+    private TbDccRepository tbDccRepository;
+
+    @Autowired
+    private TbDccLnRepository tbDccLnRepository;
+
+    @Autowired
+    private TbPurchaseOrderRepository tbPurchaseOrderRepository;
+
+    @Autowired
+    private TbPurchaseOrderUplRepository tbPurchaseOrderUplRepository;
+
+    @Autowired
+    private TbCategoryApprovalRequestsRepository tbCategoryApprovalRequestsRepository;
+
+    @Autowired
+    private TbCategoryApprovalsRepository tbCategoryApprovalsRepository;
+
+    @Autowired
+    private AcceptanceRequestReceiptRepository acceptanceRequestReceiptRepository;
+
+    private static final DateTimeFormatter DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("d-MMM-yyyy").withZone(ZoneId.of("Africa/Nairobi"));
+
+    @Async("taskExecutor")
+    public CompletableFuture<List<DccPOCombinedViewDTO>> getAllDccPOForApproverExport(
+            String supplierId, String pendingApprovers, String columnName, String searchQuery, String operator) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                logger.info("Starting approver export with supplierId: {}, pendingApprovers: {}, columnName: {}, searchQuery: {}, operator: {}",
+                        supplierId, pendingApprovers, columnName, searchQuery, operator);
+
+                // CRITICAL: Build specification EXACTLY like DccPOApproverService
+                Specification<DCC> spec = new DccSpecification(supplierId, null, columnName, searchQuery, operator);
+
+                if (pendingApprovers != null && !pendingApprovers.isEmpty()) {
+                    Integer approverIdAsInt;
+                    try {
+                        approverIdAsInt = Integer.parseInt(pendingApprovers);
+                    } catch (NumberFormatException e) {
+                        logger.error("Failed to parse pendingApprovers '{}' as Integer", pendingApprovers, e);
+                        return new ArrayList<>();
+                    }
+
+                    // Step 1: Get approvals where user has TAKEN ACTION
+                    List<TbCategoryApprovals> approvals = tbCategoryApprovalsRepository.findByApprovedBy(pendingApprovers).stream()
+                            .filter(a -> {
+                                if ("pending".equals(a.getStatus())) {
+                                    return "request-info".equals(a.getApprovalStatus());
+                                }
+                                return true;
+                            })
+                            .collect(Collectors.toList());
+
+                    logger.debug("Raw approvals by user {}: {}", approverIdAsInt, approvals.size());
+
+                    Set<Long> approvalRecordIds = approvals.stream()
+                            .map(TbCategoryApprovals::getApprovalRecordId)
+                            .collect(Collectors.toSet());
+
+                    logger.debug("Approvals found (actioned only): {} for approver {}", approvalRecordIds.size(), approverIdAsInt);
+
+                    // Step 2: Get receipts by this user
+                    List<AcceptanceRequestReceipt> userReceipts =
+                            acceptanceRequestReceiptRepository.findByApprovedBy(approverIdAsInt);
+
+                    Set<Long> userReceiptIds = userReceipts.stream()
+                            .map(r -> r.getCategoryApprovalRequestId().longValue())
+                            .collect(Collectors.toSet());
+
+                    logger.debug("Receipts found for approver {}: {}", pendingApprovers, userReceiptIds.size());
+
+                    // Step 3: Combine approval and receipt record IDs
+                    Set<Long> combinedRecordIds = new HashSet<>(approvalRecordIds);
+                    combinedRecordIds.addAll(userReceiptIds);
+
+                    logger.debug("Combined record IDs (actioned approvals + receipts): {}", combinedRecordIds.size());
+
+                    if (combinedRecordIds.isEmpty()) {
+                        logger.info("No approval or receipt actions found for user: {}", pendingApprovers);
+                        return new ArrayList<>();
+                    }
+
+                    // Step 4: Fetch related requests
+                    List<TbCategoryApprovalRequests> requests =
+                            tbCategoryApprovalRequestsRepository.findByRecordNoIn(new ArrayList<>(combinedRecordIds));
+
+                    Set<Long> dccRecordNos = requests.stream()
+                            .filter(r -> r.getAcceptanceRequestRecordNo() != null)
+                            .map(TbCategoryApprovalRequests::getAcceptanceRequestRecordNo)
+                            .collect(Collectors.toSet());
+
+                    if (dccRecordNos.isEmpty()) {
+                        logger.info("No DCC records found for user: {}", pendingApprovers);
+                        return new ArrayList<>();
+                    }
+
+                    logger.debug("Final DCC record count for user {}: {}", pendingApprovers, dccRecordNos.size());
+
+                    // Apply DCC filter to specification
+                    spec = spec.and((root, query, cb) -> root.get("recordNo").in(dccRecordNos));
+                }
+
+                // Fetch ALL DCC records
+                Pageable pageable = PageRequest.of(0, Integer.MAX_VALUE, Sort.by(Sort.Direction.DESC, "recordNo"));
+                Page<DCC> dccPage = tbDccRepository.findAll(spec, pageable);
+                List<DCC> dccList = dccPage.getContent();
+                long totalFilteredRecords = dccPage.getTotalElements();
+
+                if (dccList.isEmpty()) {
+                    logger.info("No records found for approver export");
+                    return new ArrayList<>();
+                }
+
+                logger.info("Fetched {} DCC records for approver export", dccList.size());
+
+                // Validate no invalid records
+                List<DCC> invalidDccRecords = dccList.stream()
+                        .filter(dcc -> dcc.getPoNumber() == null || dcc.getPoNumber().isEmpty())
+                        .collect(Collectors.toList());
+                if (!invalidDccRecords.isEmpty()) {
+                    logger.error("Found {} DCC records with missing or invalid poNumber", invalidDccRecords.size());
+                    throw new DccPOProcessingException("Invalid DCC records detected with missing poNumber");
+                }
+
+                // Bulk fetch all related data
+                Set<String> poNumbersSet = dccList.stream().map(DCC::getPoNumber).collect(Collectors.toSet());
+                List<String> poNumbers = new ArrayList<>(poNumbersSet);
+
+                Map<String, List<tbPurchaseOrder>> purchaseOrderMap = tbPurchaseOrderRepository.findByPoNumberIn(poNumbers)
+                        .stream().collect(Collectors.groupingBy(tbPurchaseOrder::getPoNumber));
+
+                Map<String, List<tb_PurchaseOrderUPL>> uplMap = tbPurchaseOrderUplRepository.findByPoNumberIn(poNumbers)
+                        .stream().collect(Collectors.groupingBy(tb_PurchaseOrderUPL::getPoNumber));
+
+                List<Long> dccIds = dccList.stream().map(DCC::getRecordNo).collect(Collectors.toList());
+                List<DCCLineItem> allDccLn = tbDccLnRepository.findByDccIdIn(dccIds.stream().map(String::valueOf).collect(Collectors.toList()));
+
+                Map<Long, DCC> dccMap = dccList.stream().collect(Collectors.toMap(DCC::getRecordNo, Function.identity()));
+
+                Map<String, Double> deliveredMap = allDccLn.stream()
+                        .filter(dln -> {
+                            DCC dd = dccMap.get(Long.parseLong(dln.getDccId()));
+                            return dd != null && !Arrays.asList("incomplete", "rejected").contains(dd.getStatus().toLowerCase()) && dln.getDeliveredQty() != null;
+                        })
+                        .collect(Collectors.groupingBy(
+                                dln -> dln.getPoId() + "-" + dln.getLineNumber() + "-" + (dln.getUplLineNumber() != null ? dln.getUplLineNumber() : ""),
+                                Collectors.summingDouble(DCCLineItem::getDeliveredQty)
+                        ));
+
+                List<tb_PurchaseOrderUPL> allUplList = uplMap.values().stream().flatMap(List::stream).collect(Collectors.toList());
+                Map<String, Double> acceptanceByPoLine = allUplList.stream()
+                        .filter(u -> u.getUplLineQuantity() != null && u.getUplLineQuantity() > 0
+                                && u.getPoLineQuantity() != null && u.getPoLineQuantity() > 0
+                                && u.getPoLineUnitPrice() != null && u.getPoLineUnitPrice() > 0)
+                        .collect(Collectors.groupingBy(
+                                u -> u.getPoNumber() + "-" + u.getPoLineNumber(),
+                                Collectors.summingDouble(u -> {
+                                    double denominator = u.getPoLineQuantity() * u.getPoLineUnitPrice();
+                                    if (denominator == 0) {
+                                        return 0.0;
+                                    }
+                                    double numerator = u.getUplLineQuantity() * u.getPoLineQuantity();
+                                    return numerator / denominator;
+                                })
+                        ));
+
+                Set<String> hasDccLnSet = allDccLn.stream()
+                        .map(dln -> dln.getPoId() + "-" + dln.getLineNumber() + "-" + (dln.getUplLineNumber() != null ? dln.getUplLineNumber() : ""))
+                        .collect(Collectors.toSet());
+
+                List<TbCategoryApprovalRequests> allRequests = tbCategoryApprovalRequestsRepository
+                        .findByAcceptanceRequestRecordNoInOrderByAcceptanceRequestRecordNoAscRecordDateTimeDesc(dccIds);
+
+                Map<Long, List<TbCategoryApprovalRequests>> requestsByDccId = allRequests.stream()
+                        .collect(Collectors.groupingBy(TbCategoryApprovalRequests::getAcceptanceRequestRecordNo));
+
+                Set<Long> allRequestRecordNos = allRequests.stream().map(TbCategoryApprovalRequests::getRecordNo).collect(Collectors.toSet());
+
+                List<TbCategoryApprovals> allApprovals = tbCategoryApprovalsRepository.findByApprovalRecordIdIn(new ArrayList<>(allRequestRecordNos));
+
+                Map<Long, List<TbCategoryApprovals>> approvalsByRequestRecordNo = allApprovals.stream()
+                        .collect(Collectors.groupingBy(TbCategoryApprovals::getApprovalRecordId));
+
+                SimpleDateFormat dateFormat = new SimpleDateFormat("d-MMM-yyyy");
+
+                // Process all records in parallel
+                List<DccPOCombinedViewDTO> result = dccList.parallelStream()
+                        .flatMap(dcc -> {
+                            List<tbPurchaseOrder> purchaseOrderList = purchaseOrderMap.getOrDefault(dcc.getPoNumber(), Collections.emptyList());
+                            if (purchaseOrderList.isEmpty()) {
+                                logger.error("No Purchase Order found for poNumber: {} in DCC record: {}.", dcc.getPoNumber(), dcc.getRecordNo());
+                                return Stream.empty();
+                            }
+                            tbPurchaseOrder purchaseOrder = purchaseOrderList.get(0);
+
+                            List<tb_PurchaseOrderUPL> uplList = uplMap.getOrDefault(dcc.getPoNumber(), Collections.emptyList());
+                            List<DCCLineItem> dccLnList = allDccLn.stream()
+                                    .filter(dln -> dln.getDccId().equals(String.valueOf(dcc.getRecordNo())))
+                                    .collect(Collectors.toList());
+
+                            List<TbCategoryApprovalRequests> dccRequests = requestsByDccId.getOrDefault(dcc.getRecordNo(), Collections.emptyList());
+                            TbCategoryApprovalRequests latestApprovalRequest = dccRequests.stream()
+                                    .max(Comparator.comparing(TbCategoryApprovalRequests::getRecordDateTime))
+                                    .orElse(null);
+
+                            List<TbCategoryApprovals> allRelatedApprovals = dccRequests.stream()
+                                    .flatMap(r -> approvalsByRequestRecordNo.getOrDefault(r.getRecordNo(), Collections.emptyList()).stream())
+                                    .collect(Collectors.toList());
+
+                            if (dccLnList.isEmpty() || uplList.isEmpty()) {
+                                logger.warn("No DCC_LN or UPL records found for DCC ID: {}. Skipping.", dcc.getRecordNo());
+                                return Stream.empty();
+                            }
+
+                            return buildDccPOCombinedViewDTOs(dcc, purchaseOrder, uplList, dccLnList, latestApprovalRequest, dccRequests, allRelatedApprovals,
+                                    deliveredMap, acceptanceByPoLine, hasDccLnSet, dateFormat).stream();
+                        })
+                        .collect(Collectors.toList());
+
+                logger.info("Exported {} records successfully for approver", result.size());
+                return result;
+            } catch (Exception ex) {
+                logger.error("Error during approver export of DCC PO Combined View", ex);
+                throw new DccPOProcessingException("Failed to export DCC PO Combined View for approvers", ex);
+            }
+        });
+    }
+
+    private List<DccPOCombinedViewDTO> buildDccPOCombinedViewDTOs(
+            DCC dcc, tbPurchaseOrder purchaseOrder, List<tb_PurchaseOrderUPL> uplList,
+            List<DCCLineItem> dccLnList, TbCategoryApprovalRequests latestApprovalRequest,
+            List<TbCategoryApprovalRequests> allRelatedRequests, List<TbCategoryApprovals> allRelatedApprovals, Map<String, Double> deliveredMap,
+            Map<String, Double> acceptanceByPoLine, Set<String> hasDccLnSet, SimpleDateFormat dateFormat) {
+        List<DccPOCombinedViewDTO> dtos = new ArrayList<>();
+
+        // Optimize matching with maps
+        Map<String, tb_PurchaseOrderUPL> uplByKey = uplList.stream()
+                .collect(Collectors.toMap(u -> (u.getUplLine() != null ? u.getUplLine() : "") + "-" + u.getPoLineNumber() + "-" + u.getPoNumber(), u -> u));
+
+        for (DCCLineItem dccLn : dccLnList) {
+            String key = (dccLn.getUplLineNumber() != null ? dccLn.getUplLineNumber() : "") + "-" + dccLn.getLineNumber() + "-" + dcc.getPoNumber();
+            tb_PurchaseOrderUPL upl = uplByKey.get(key);
+            if (upl == null) {
+                logger.debug("No matching UPL record for DCC recordNo: {}, poNumber: {}, poLineNumber: {}, uplLine: {}",
+                        dcc.getRecordNo(), dcc.getPoNumber(), dccLn.getLineNumber(), dccLn.getUplLineNumber());
+                continue;
+            }
+
+            // Fallback condition
+            boolean condition = (dccLn.getUplLineNumber() != null && !dccLn.getUplLineNumber().isEmpty())
+                    ? (dccLn.getUplLineNumber().equals(upl.getUplLine()) &&
+                    upl.getPoLineNumber().equals(dccLn.getLineNumber()) &&
+                    upl.getPoNumber().equals(dcc.getPoNumber()))
+                    : (purchaseOrder.getLineNumber().equals(dccLn.getLineNumber()) &&
+                    purchaseOrder.getPoNumber().equals(dcc.getPoNumber()));
+            if (!condition) continue;
+
+            DccPOCombinedViewDTO dto = new DccPOCombinedViewDTO();
+            populateDccFields(dto, dcc, dateFormat, latestApprovalRequest);
+            populateLineItemFields(dto, dccLn, dateFormat, new HashSet<>());
+            populatePurchaseOrderAndUplFields(dto, dccLn, purchaseOrder, upl);
+            calculateQuantitiesAndApprovals(dto, dcc, purchaseOrder, upl, deliveredMap, acceptanceByPoLine, hasDccLnSet, latestApprovalRequest, allRelatedRequests, allRelatedApprovals);
+
+            dtos.add(dto);
+        }
+
+        return dtos;
+    }
+
+    private void populateDccFields(DccPOCombinedViewDTO dto, DCC dcc, SimpleDateFormat dateFormat,
+                                   TbCategoryApprovalRequests latestApprovalRequest) {
+        dto.setDccRecordNo(dcc.getRecordNo());
+        dto.setDccPoNumber(dcc.getPoNumber());
+        dto.setDccVendorName(dcc.getVendorName());
+        dto.setDccVendorEmail(dcc.getVendorEmail());
+        // REMOVED: dto.setDccProjectName(dcc.getProjectName());
+        // DO NOT set projectName here - it will be set from PurchaseOrder table in populatePurchaseOrderAndUplFields
+        dto.setDccAcceptanceType(dcc.getAcceptanceType());
+        dto.setDccStatus(dcc.getStatus());
+
+        if (dcc.getCreatedDate() != null) {
+            Instant instant = Instant.ofEpochMilli(dcc.getCreatedDate().getTime());
+            dto.setDccCreatedDate(instant.atZone(ZoneId.of("Africa/Nairobi")).format(DATE_FORMATTER));
+        } else {
+            dto.setDccCreatedDate(null);
+        }
+
+        dto.setVendorComment(dcc.getVendorComment());
+        dto.setDccId(dcc.getDccId());
+        dto.setDccCurrency(dcc.getCurrency());
+        dto.setCreatedBy(dcc.getCreatedBy());
+        dto.setCreatedByName(dcc.getCreatedBy());
+
+        if (latestApprovalRequest != null && latestApprovalRequest.getApprovedDate() != null) {
+            ZonedDateTime zonedApproved = latestApprovalRequest.getApprovedDate().atZone(ZoneId.of("Africa/Nairobi"));
+            dto.setDateApproved(zonedApproved.format(DATE_FORMATTER));
+        } else {
+            dto.setDateApproved(null);
+        }
+    }
+
+    private void populateLineItemFields(DccPOCombinedViewDTO dto, DCCLineItem dccLn, SimpleDateFormat dateFormat,
+                                        Set<Long> loggedInvalidLinkIds) {
+        dto.setLnRecordNo(dccLn.getRecordNo());
+        dto.setLnProductName(dccLn.getProductName());
+        dto.setLnProductSerialNo(dccLn.getSerialNumber());
+        dto.setLnDeliveredQty(dccLn.getDeliveredQty());
+        dto.setLnLocationName(dccLn.getLocationName());
+
+        if (dccLn.getDateInService() != null) {
+            Instant instant = Instant.ofEpochMilli(dccLn.getDateInService().getTime());
+            dto.setLnInserviceDate(instant.atZone(ZoneId.of("Africa/Nairobi")).format(DATE_FORMATTER));
+        } else {
+            dto.setLnInserviceDate(null);
+        }
+
+        dto.setLnUnitPrice(dccLn.getUnitPrice() != null ? dccLn.getUnitPrice() : 0.0);
+        dto.setLnScopeOfWork(dccLn.getScopeOfWork());
+        dto.setLnRemarks(dccLn.getRemarks());
+        dto.setLinkId(dccLn.getLinkId());
+        dto.setTagNumber(dccLn.getTagNumber());
+        dto.setLineNumber(dccLn.getLineNumber());
+        dto.setActualItemCode(dccLn.getActualItemCode());
+        dto.setUplLineNumber(dccLn.getUplLineNumber());
+        dto.setpoAcceptanceQty(dccLn.getpoAcceptanceQty());
+    }
+
+    private void populatePurchaseOrderAndUplFields(DccPOCombinedViewDTO dto, DCCLineItem dccLn,
+                                                   tbPurchaseOrder purchaseOrder, tb_PurchaseOrderUPL upl) {
+        dto.setPoId(purchaseOrder.getPoNumber());
+
+        // CRITICAL FIX: Use newProjectName with fallback to projectName
+        dto.setProjectName(
+                purchaseOrder.getNewProjectName() != null && !purchaseOrder.getNewProjectName().isEmpty()
+                        ? purchaseOrder.getNewProjectName()
+                        : purchaseOrder.getProjectName()
+        );
+        dto.setNewProjectName(purchaseOrder.getNewProjectName());
+
+        dto.setSupplierId(purchaseOrder.getVendorNumber());
+        dto.setVendorNumber(purchaseOrder.getVendorNumber());
+        dto.setVendorName(purchaseOrder.getVendorName());
+
+        double poOrderQty = (dccLn.getUplLineNumber() != null && !dccLn.getUplLineNumber().isEmpty())
+                ? upl.getPoLineQuantity()
+                : parsePoOrderQuantity(purchaseOrder);
+        dto.setPoLineQuantity(poOrderQty);
+        dto.setPoOrderQuantity(poOrderQty);
+        dto.setPoLineDescription(upl.getPoLineDescription());
+        dto.setUplLineQuantity(upl.getUplLineQuantity());
+        dto.setUplLineItemCode(upl.getUplLineItemCode());
+        dto.setUplLineDescription(upl.getUplLineDescription());
+        dto.setUnitOfMeasure(upl.getUom());
+        dto.setActiveOrPassive(upl.getActiveOrPassive());
+        dto.setItemCode(upl.getUplLineItemCode());
+        dto.setItemPartNumber(upl.getPoLineItemCode());
+    }
+
+    private void calculateQuantitiesAndApprovals(DccPOCombinedViewDTO dto, DCC dcc, tbPurchaseOrder purchaseOrder,
+                                                 tb_PurchaseOrderUPL upl, Map<String, Double> deliveredMap,
+                                                 Map<String, Double> acceptanceByPoLine, Set<String> hasDccLnSet,
+                                                 TbCategoryApprovalRequests latestApprovalRequest,
+                                                 List<TbCategoryApprovalRequests> allRelatedRequests,
+                                                 List<TbCategoryApprovals> allRelatedApprovals) {
+        // totalDelivered using precomputed map
+        String deliveredKey = upl.getPoNumber() + "-" + upl.getPoLineNumber() + "-" + (upl.getUplLine() != null ? upl.getUplLine() : "");
+        double totalDelivered = deliveredMap.getOrDefault(deliveredKey, 0.0);
+        dto.setUPLACPTRequestValue(totalDelivered);
+
+        // POLineAcceptanceQty using precomputed
+        String poLineKey = upl.getPoNumber() + "-" + upl.getPoLineNumber();
+        double poLineAcceptanceQty = acceptanceByPoLine.getOrDefault(poLineKey, 0.0);
+        dto.setPOLineAcceptanceQty(poLineAcceptanceQty);
+
+        // poPendingQuantity
+        boolean exists = hasDccLnSet.contains(deliveredKey);
+        double poPendingQuantity = exists ? poLineAcceptanceQty : (upl.getPoLineQuantity() != null ? upl.getPoLineQuantity() : 0.0);
+        dto.setPoPendingQuantity(poPendingQuantity);
+
+        // uplPendingQuantity
+        double uplPending = upl.getUplLineQuantity() != null ? upl.getUplLineQuantity() - totalDelivered : 0.0;
+        dto.setUplPendingQuantity(Math.max(uplPending, 0.0));
+
+        // Approval fields using pre-fetched allRelatedApprovals
+        if (latestApprovalRequest != null) {
+            calculateApprovalFields(dto, latestApprovalRequest, allRelatedRequests, allRelatedApprovals);
+        } else {
+            dto.setApprovalCount(0L);
+            dto.setPendingApprovers(null);
+            dto.setApproverComment(null);
+            dto.setUserAging("0 days 0 hrs 0 mins");
+            dto.setTotalAging("0 days 0 hrs 0 mins");
+        }
+    }
+
+    private void calculateApprovalFields(DccPOCombinedViewDTO dto, TbCategoryApprovalRequests latestApprovalRequest,
+                                         List<TbCategoryApprovalRequests> allRelatedRequests,
+                                         List<TbCategoryApprovals> allRelatedApprovals) {
+        List<String> validRequestStatuses = Arrays.asList("pending", "returned");
+        List<String> validApprovalStatuses = Arrays.asList("pending", "readyForApproval", "request-info");
+        ZonedDateTime now = ZonedDateTime.now();
+        LocalDateTime nowLocal = now.toLocalDateTime();
+
+        // Shared calculations
+        String totalAging = calculateTotalAging(allRelatedApprovals, latestApprovalRequest, nowLocal);
+        String approverComment = getLatestComment(allRelatedApprovals);
+
+        // Handle terminal statuses: approved, rejected
+        if ("approved".equalsIgnoreCase(latestApprovalRequest.getStatus()) || "rejected".equalsIgnoreCase(latestApprovalRequest.getStatus())) {
+            dto.setApprovalCount(0L);
+            dto.setPendingApprovers(null);
+            dto.setUserAging("0 days 0 hrs 0 mins");
+            dto.setTotalAging(totalAging);
+            dto.setApproverComment(approverComment);
+            return;
+        }
+
+        // Determine the current approver for the latest approval request
+        String currentApproverName = allRelatedApprovals.stream()
+                .filter(a -> a.getApprovalRecordId().equals(latestApprovalRequest.getRecordNo()))
+                .filter(a -> "pending".equals(a.getStatus()) && "request-info".equals(a.getApprovalStatus()))
+                .sorted(Comparator.comparing(TbCategoryApprovals::getApprovalId))
+                .findFirst()
+                .map(TbCategoryApprovals::getApproverName)
+                .orElse(null);
+
+        // Calculate userAging2: Historical paused periods for request-info
+        long userAging2Minutes = allRelatedApprovals.stream()
+                .filter(a -> "request-info".equals(a.getStatus()) && "request-info".equals(a.getApprovalStatus()))
+                .filter(a -> currentApproverName != null && currentApproverName.equals(a.getApproverName()))
+                .filter(a -> a.getApprovedDate() != null && a.getRecordDateTime() != null)
+                .mapToLong(a -> Math.max(Duration.between(a.getRecordDateTime(), a.getApprovedDate()).toMinutes(), 0))
+                .sum();
+
+        // Handle request-info case
+        if ("request-info".equals(latestApprovalRequest.getStatus())) {
+            List<TbCategoryApprovals> filteredApprovals = allRelatedApprovals.stream()
+                    .filter(a -> "pending".equals(a.getStatus()) && Arrays.asList("pending", "request-info").contains(a.getApprovalStatus()))
+                    .filter(a -> allRelatedRequests.stream().anyMatch(r -> "request-info".equals(r.getStatus()) && r.getRecordNo().equals(a.getApprovalRecordId())))
+                    .sorted(Comparator.comparing(TbCategoryApprovals::getApprovalId).reversed())
+                    .collect(Collectors.toList());
+
+            dto.setApprovalCount((long) filteredApprovals.size());
+            dto.setPendingApprovers(currentApproverName);
+
+            long userAging1Minutes = allRelatedApprovals.stream()
+                    .filter(a -> a.getApprovalRecordId().equals(latestApprovalRequest.getRecordNo()))
+                    .filter(a -> "pending".equals(a.getStatus()) && "request-info".equals(a.getApprovalStatus()))
+                    .filter(a -> currentApproverName != null && currentApproverName.equals(a.getApproverName()))
+                    .filter(a -> a.getRecordDateTime() != null && a.getApprovedDate() != null)
+                    .mapToLong(a -> Math.max(Duration.between(a.getRecordDateTime(), a.getApprovedDate()).toMinutes(), 0))
+                    .sum();
+
+            long totalUserAgingMinutes = userAging1Minutes + userAging2Minutes;
+            dto.setUserAging(String.format("%d days %d hrs %d mins",
+                    totalUserAgingMinutes / 1440, (totalUserAgingMinutes / 60) % 24, totalUserAgingMinutes % 60));
+            dto.setTotalAging(totalAging);
+            dto.setApproverComment(approverComment);
+            return;
+        }
+
+        // Handle returned case
+        if ("returned".equals(latestApprovalRequest.getStatus())) {
+            dto.setApprovalCount(0L);
+            dto.setPendingApprovers(null);
+            dto.setUserAging("0 days 0 hrs 0 mins");
+            dto.setTotalAging(totalAging);
+            dto.setApproverComment(approverComment);
+            return;
+        }
+
+        // Logic for pending status
+        List<TbCategoryApprovals> filteredApprovals = allRelatedApprovals.stream()
+                .filter(a -> "pending".equals(a.getStatus()) && Arrays.asList("pending", "readyForApproval").contains(a.getApprovalStatus()))
+                .filter(a -> allRelatedRequests.stream().anyMatch(r -> "pending".equals(r.getStatus()) && r.getRecordNo().equals(a.getApprovalRecordId())))
+                .sorted(Comparator.comparing(TbCategoryApprovals::getApprovalId).reversed())
+                .collect(Collectors.toList());
+
+        dto.setApprovalCount((long) filteredApprovals.size());
+
+        Optional<TbCategoryApprovals> readyForApproval = filteredApprovals.stream()
+                .filter(a -> "readyForApproval".equals(a.getApprovalStatus()))
+                .sorted(Comparator.comparing(TbCategoryApprovals::getApprovalId))
+                .findFirst();
+
+        String pendingApproverName = readyForApproval
+                .map(TbCategoryApprovals::getApproverName)
+                .orElseGet(() -> filteredApprovals.stream()
+                        .filter(a -> validApprovalStatuses.contains(a.getApprovalStatus()))
+                        .sorted(Comparator.comparing(TbCategoryApprovals::getApprovalId))
+                        .findFirst()
+                        .map(TbCategoryApprovals::getApproverName)
+                        .orElse(null));
+        dto.setPendingApprovers(pendingApproverName);
+
+        // Calculate totalPausedUserAgingMinutes for historical request-info
+        long totalPausedUserAgingMinutes = allRelatedApprovals.stream()
+                .filter(a -> "request-info".equals(a.getStatus()) && "request-info".equals(a.getApprovalStatus()))
+                .filter(a -> pendingApproverName != null && pendingApproverName.equals(a.getApproverName()))
+                .filter(a -> a.getApprovedDate() != null && a.getRecordDateTime() != null)
+                .mapToLong(a -> Math.max(Duration.between(a.getRecordDateTime(), a.getApprovedDate()).toMinutes(), 0))
+                .sum();
+
+        // Calculate currentUserAgingMinutes using latest readyForApproval
+        long currentUserAgingMinutes = 0;
+        if (pendingApproverName != null) {
+            Optional<LocalDateTime> latestReadyForApprovalDate = filteredApprovals.stream()
+                    .filter(a -> "readyForApproval".equals(a.getApprovalStatus()) && pendingApproverName.equals(a.getApproverName()))
+                    .map(TbCategoryApprovals::getRecordDateTime)
+                    .filter(Objects::nonNull)
+                    .max(LocalDateTime::compareTo);
+            currentUserAgingMinutes = latestReadyForApprovalDate
+                    .map(date -> Duration.between(date, nowLocal).toMinutes())
+                    .orElseGet(() -> latestApprovalRequest.getRecordDateTime() != null
+                            ? Duration.between(latestApprovalRequest.getRecordDateTime(), nowLocal).toMinutes()
+                            : 0L);
+            currentUserAgingMinutes = Math.max(currentUserAgingMinutes, 0);
+        }
+
+        long totalUserAgingMinutes = totalPausedUserAgingMinutes + currentUserAgingMinutes;
+        dto.setUserAging(String.format("%d days %d hrs %d mins",
+                totalUserAgingMinutes / 1440, (totalUserAgingMinutes / 60) % 24, totalUserAgingMinutes % 60));
+        dto.setTotalAging(totalAging);
+        dto.setApproverComment(approverComment);
+    }
+
+    private String calculateTotalAging(List<TbCategoryApprovals> allRelatedApprovals,
+                                       TbCategoryApprovalRequests latestApprovalRequest,
+                                       LocalDateTime nowLocal) {
+        LocalDateTime minRecordDateTime = allRelatedApprovals.stream()
+                .map(TbCategoryApprovals::getRecordDateTime)
+                .filter(Objects::nonNull)
+                .min(LocalDateTime::compareTo)
+                .orElse(latestApprovalRequest.getRecordDateTime() != null
+                        ? latestApprovalRequest.getRecordDateTime()
+                        : nowLocal);
+
+        LocalDateTime endDate = allRelatedApprovals.stream()
+                .filter(a -> "pending".equals(a.getStatus()) && "pending".equals(a.getApprovalStatus()))
+                .findAny()
+                .map(a -> nowLocal)
+                .orElseGet(() -> allRelatedApprovals.stream()
+                        .map(TbCategoryApprovals::getApprovedDate)
+                        .filter(Objects::nonNull)
+                        .max(LocalDateTime::compareTo)
+                        .orElse(nowLocal));
+
+        long totalAgingMinutes = Math.max(Duration.between(minRecordDateTime, endDate).toMinutes(), 0);
+        return String.format("%d days %d hrs %d mins",
+                totalAgingMinutes / 1440, (totalAgingMinutes / 60) % 24, totalAgingMinutes % 60);
+    }
+
+    private String getLatestComment(List<TbCategoryApprovals> allRelatedApprovals) {
+        return allRelatedApprovals.stream()
+                .filter(a -> !"pending".equals(a.getApprovalStatus()) && !"readyForApproval".equals(a.getApprovalStatus()))
+                .filter(a -> a.getComments() != null)
+                .sorted(Comparator.comparing(TbCategoryApprovals::getApprovalId).reversed())
+                .map(TbCategoryApprovals::getComments)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private double parsePoOrderQuantity(tbPurchaseOrder purchaseOrder) {
+        String poQtyNew = String.valueOf(purchaseOrder.getPoQtyNew());
+        return (poQtyNew != null && !poQtyNew.isEmpty()) ? Double.parseDouble(poQtyNew) : purchaseOrder.getAmountDueLine();
+    }
+}

--- a/src/main/java/com/zain/almksazain/serviceImplementors/DccPOService.java
+++ b/src/main/java/com/zain/almksazain/serviceImplementors/DccPOService.java
@@ -676,7 +676,23 @@ public class DccPOService {
         return (poQtyNew != null && !poQtyNew.isEmpty()) ? Double.parseDouble(poQtyNew) : purchaseOrder.getAmountDueLine();
     }
 
+    // Add this method to DccPOService.java
+    public DccPOFetchResult getDccPOCombinedViewSync(
+            String supplierId,
+            String pendingApprovers,
+            int page,
+            int size,
+            String columnName,
+            String searchQuery,
+            boolean exporting,
+            String operator) {
 
+        logger.info("Starting SYNCHRONOUS retrieval of DCC PO Combined View with supplierId: {}, pendingApprovers: {}, page: {}, size: {}, columnName: {}, searchQuery: {}, exporting: {}, operator: {}",
+                supplierId, pendingApprovers, page, size, columnName, searchQuery, exporting, operator);
+
+        // Call the private method directly (synchronously)
+        return fetchDccPOCombinedView(supplierId, pendingApprovers, page, size, columnName, searchQuery, exporting, operator);
+    }
 
    // service method export for excelendpoint
     @Async("taskExecutor")

--- a/src/main/java/com/zain/almksazain/serviceImplementors/DccPOService.java
+++ b/src/main/java/com/zain/almksazain/serviceImplementors/DccPOService.java
@@ -676,7 +676,7 @@ public class DccPOService {
         return (poQtyNew != null && !poQtyNew.isEmpty()) ? Double.parseDouble(poQtyNew) : purchaseOrder.getAmountDueLine();
     }
 
-    // Add this method to DccPOService.java
+    // Synchronous method for filter endpoint to avoid async blocking with CompletableFuture.get()
     public DccPOFetchResult getDccPOCombinedViewSync(
             String supplierId,
             String pendingApprovers,


### PR DESCRIPTION
## Changes
- **Service Layer**: Added `getDccPOCombinedViewSync()` method for synchronous data retrieval
- **Controller**: Implemented `/filter` POST endpoint following ScopeApproval pattern
- **Response Structure**: Returns parent-only records without line items for optimal performance
- **Filtering**: Supports field-specific filters (dccStatus, vendorName, dates, etc.) with in-memory processing
- **Operator Support**: Handles AND/OR operators for flexible query combinations