### PR TITLE
Fix multi-filter endpoint - map supplierId to vendorNumber in DccSpec…

### DIFF
--- a/src/main/java/com/zain/almksazain/serviceImplementors/DccSpecification.java
+++ b/src/main/java/com/zain/almksazain/serviceImplementors/DccSpecification.java
@@ -300,7 +300,7 @@ public class DccSpecification implements Specification<DCC> {
             case "dcccurrency":
             case "currency": return "currency";
             case "vendoremail": return "vendorEmail";
-            case "supplierid": return "supplierId";
+            case "supplierid": return "vendorNumber";  // ← FIX: Map to vendorNumber, not supplierId
             default: return null;
         }
     }


### PR DESCRIPTION
## Problem
Multi-filter endpoint returns empty results when `supplierId` is provided in the request body.

## Root Cause
In `DccSpecification.java`, the field mapping was incorrect:
```java
case "supplierid": return "supplierId";  // ❌ Field doesn't exist in DCC table
```

## Solution
Fixed the mapping to use the correct database column:
```java
case "supplierid": return "vendorNumber";  // ✅ Correct mapping
```
## Files Changed
- `DccSpecification.java` - 1 line changed