### PR TITLE
Fix: Capitalization export row count mismatch due to poNumber filter

### DIFF
--- a/src/main/java/com/zain/almksazain/controller/ExportsController.java
+++ b/src/main/java/com/zain/almksazain/controller/ExportsController.java
@@ -248,288 +248,294 @@ public class ExportsController {
     // Capitalization Report Export
     // ============================================================================
 
-    @PostMapping(value = "/reports/v2/capitalizationReport/export")
-    public void exportCapitalizationReport(@RequestBody String req,
-                                           HttpServletResponse response) throws IOException {
+@PostMapping(value = "/reports/v2/capitalizationReport/export")
+public void exportCapitalizationReport(@RequestBody String req,
+                                       HttpServletResponse response) throws IOException {
 
-        JsonObject obj = JsonParser.parseString(req).getAsJsonObject();
+    JsonObject obj = JsonParser.parseString(req).getAsJsonObject();
 
-        Map<String, String> searchableColumns = new HashMap<>();
-        searchableColumns.put("requestId",                      "DCC.recordNo");
-        searchableColumns.put("poNumber",                       "DCC.poNumber");
-        searchableColumns.put("poLineNumber",                   "LN2.lineNumber");
-        searchableColumns.put("uplLineNumber",                  "LN2.uplLineNumber");
-        searchableColumns.put("siteId",                         "LN2.locationName");
-        searchableColumns.put("linkId",                         "LN2.linkId");
-        searchableColumns.put("isd",                            "LN2.dateInService");
-        searchableColumns.put("region",                         "rg.regionName");
-        searchableColumns.put("siteTypeName",                   "siteType.siteTypeName");
-        searchableColumns.put("projectName",                    "(CASE WHEN HD.newProjectName IS NULL OR LENGTH(TRIM(HD.newProjectName)) = 0 THEN HD.projectName ELSE HD.newProjectName END)");
-        searchableColumns.put("description",                    "(CASE WHEN LENGTH(LN2.uplLineNumber) > 0 THEN upl.uplLineDescription ELSE HD.poLineDescription END)");
-        searchableColumns.put("quantity",                       "LN2.deliveredQty");
-        searchableColumns.put("partNumber",                     "(CASE WHEN LENGTH(LN2.uplLineNumber) > 0 THEN (CASE WHEN LENGTH(LN2.actualItemCode) > 0 THEN LN2.actualItemCode ELSE upl.uplLineItemCode END) ELSE HD.itemPartNumber END)");
-        searchableColumns.put("itemSerializedStatus",
-                "(CASE WHEN UPPER(TRIM(upl.uplItemSerialized)) IN ('YES','Y','TRUE','1') THEN 'YES' " +
-                        "WHEN UPPER(TRIM(upl.uplItemSerialized)) IN ('NO','N','FALSE','0') THEN 'NO' ELSE NULL END)");
-        searchableColumns.put("serialNumber",                   "LN2.serialNumber");
-        searchableColumns.put("uplItemCategoryCodeDescription", "upl.zainItemCategoryDescription");
-        searchableColumns.put("faBookingAmount",                "(upl.uplLineUnitPrice * LN2.deliveredQty)");
-        searchableColumns.put("currency",                       "'SAR'");
-        searchableColumns.put("tagNumber",                      "LN2.tagNumber");
-        searchableColumns.put("receiveddate",                   "rec.approvedDate");
-        searchableColumns.put("recordNo",                       "DCC.recordNo");
+    Map<String, String> searchableColumns = new HashMap<>();
+    searchableColumns.put("requestId",                      "DCC.recordNo");
+    searchableColumns.put("poNumber",                       "DCC.poNumber");
+    searchableColumns.put("poLineNumber",                   "LN2.lineNumber");
+    searchableColumns.put("uplLineNumber",                  "LN2.uplLineNumber");
+    searchableColumns.put("siteId",                         "LN2.locationName");
+    searchableColumns.put("linkId",                         "LN2.linkId");
+    searchableColumns.put("isd",                            "LN2.dateInService");
+    searchableColumns.put("region",                         "rg.regionName");
+    searchableColumns.put("siteTypeName",                   "siteType.siteTypeName");
+    searchableColumns.put("projectName",                    "(CASE WHEN HD.newProjectName IS NULL OR LENGTH(TRIM(HD.newProjectName)) = 0 THEN HD.projectName ELSE HD.newProjectName END)");
+    searchableColumns.put("description",                    "(CASE WHEN LENGTH(LN2.uplLineNumber) > 0 THEN upl.uplLineDescription ELSE HD.poLineDescription END)");
+    searchableColumns.put("quantity",                       "LN2.deliveredQty");
+    searchableColumns.put("partNumber",                     "(CASE WHEN LENGTH(LN2.uplLineNumber) > 0 THEN (CASE WHEN LENGTH(LN2.actualItemCode) > 0 THEN LN2.actualItemCode ELSE upl.uplLineItemCode END) ELSE HD.itemPartNumber END)");
+    searchableColumns.put("itemSerializedStatus",
+            "(CASE WHEN UPPER(TRIM(upl.uplItemSerialized)) IN ('YES','Y','TRUE','1') THEN 'YES' " +
+                    "WHEN UPPER(TRIM(upl.uplItemSerialized)) IN ('NO','N','FALSE','0') THEN 'NO' ELSE NULL END)");
+    searchableColumns.put("serialNumber",                   "LN2.serialNumber");
+    searchableColumns.put("uplItemCategoryCodeDescription", "upl.zainItemCategoryDescription");
+    searchableColumns.put("faBookingAmount",                "(upl.uplLineUnitPrice * LN2.deliveredQty)");
+    searchableColumns.put("currency",                       "'SAR'");
+    searchableColumns.put("tagNumber",                      "LN2.tagNumber");
+    searchableColumns.put("receiveddate",                   "rec.approvedDate");
+    searchableColumns.put("recordNo",                       "DCC.recordNo");
 
-        Set<String> numericColumns = new HashSet<>(Arrays.asList(
-                "requestId", "poLineNumber", "uplLineNumber", "sequenceNo", "quantity"
-        ));
+    Set<String> numericColumns = new HashSet<>(Arrays.asList(
+            "requestId", "poLineNumber", "uplLineNumber", "sequenceNo", "quantity"
+    ));
 
-        Set<String> controlKeys = new HashSet<>(Arrays.asList(
-                "receivedDateFrom", "receivedDateTo", "isdFrom", "isdTo",
-                "page", "size", "sort", "filters", "columnName", "searchQuery"
-        ));
+    Set<String> controlKeys = new HashSet<>(Arrays.asList(
+            "poNumber",                                         
+            "receivedDateFrom", "receivedDateTo", "isdFrom", "isdTo",
+            "page", "size", "sort", "filters", "columnName", "searchQuery"
+    ));
 
-        JsonObject filtersObj = new JsonObject();
-        if (obj.has("filters") && obj.get("filters").isJsonObject()) {
-            filtersObj = obj.getAsJsonObject("filters");
-        } else {
-            for (Map.Entry<String, JsonElement> ent : obj.entrySet()) {
-                String key = ent.getKey();
-                if (controlKeys.contains(key)) continue;
-                JsonElement val = ent.getValue();
-                if (val == null || val.isJsonNull()) continue;
-                if (val.isJsonPrimitive()) filtersObj.add(key, val);
-            }
-            if (obj.has("columnName") && obj.has("searchQuery")) {
-                String col = obj.get("columnName").getAsString();
-                String q   = obj.get("searchQuery").getAsString();
-                if (col != null && !col.trim().isEmpty() && q != null && !q.trim().isEmpty()) {
-                    filtersObj.add(col, new JsonPrimitive(q));
-                }
-            }
+    JsonObject filtersObj = new JsonObject();
+    if (obj.has("filters") && obj.get("filters").isJsonObject()) {
+        filtersObj = obj.getAsJsonObject("filters");
+    } else {
+        for (Map.Entry<String, JsonElement> ent : obj.entrySet()) {
+            String key = ent.getKey();
+            if (controlKeys.contains(key)) continue;
+            JsonElement val = ent.getValue();
+            if (val == null || val.isJsonNull()) continue;
+            if (val.isJsonPrimitive()) filtersObj.add(key, val);
         }
-
-        StringBuilder whereClause = new StringBuilder();
-        List<Object> params = new ArrayList<>();
-
-        for (Map.Entry<String, JsonElement> entry : filtersObj.entrySet()) {
-            String columnKey = entry.getKey();
-            if (!searchableColumns.containsKey(columnKey)) continue;
-            String rawValue = entry.getValue().getAsString();
-            if (rawValue == null) continue;
-            rawValue = rawValue.trim();
-            if (rawValue.isEmpty()) continue;
-
-            String sqlCol = searchableColumns.get(columnKey);
-            if ("receiveddate".equals(columnKey) || "isd".equals(columnKey)) continue;
-
-            if (rawValue.contains(",")) {
-                String[] tokens = Arrays.stream(rawValue.split(","))
-                        .map(String::trim).filter(s -> !s.isEmpty()).toArray(String[]::new);
-                if (tokens.length == 0) continue;
-                if (numericColumns.contains(columnKey)) {
-                    whereClause.append(" AND ").append(sqlCol).append(" IN (")
-                            .append(String.join(",", Collections.nCopies(tokens.length, "?"))).append(") ");
-                    for (String t : tokens) params.add(t);
-                } else {
-                    whereClause.append(" AND (");
-                    for (int i = 0; i < tokens.length; i++) {
-                        if (i > 0) whereClause.append(" OR ");
-                        whereClause.append("LOWER(").append(sqlCol).append(") LIKE LOWER(?)");
-                        params.add("%" + tokens[i] + "%");
-                    }
-                    whereClause.append(") ");
-                }
-            } else {
-                if (numericColumns.contains(columnKey)) {
-                    whereClause.append(" AND ").append(sqlCol).append(" = ? ");
-                    params.add(rawValue);
-                } else {
-                    whereClause.append(" AND LOWER(").append(sqlCol).append(") LIKE LOWER(?) ");
-                    params.add("%" + rawValue + "%");
-                }
+        if (obj.has("columnName") && obj.has("searchQuery")) {
+            String col = obj.get("columnName").getAsString();
+            String q   = obj.get("searchQuery").getAsString();
+            if (col != null && !col.trim().isEmpty() && q != null && !q.trim().isEmpty()) {
+                filtersObj.add(col, new JsonPrimitive(q));
             }
-        }
-
-        String receivedDateFrom = convertToSqlDate(obj.has("receivedDateFrom") ? obj.get("receivedDateFrom").getAsString() : "");
-        String receivedDateTo   = convertToSqlDate(obj.has("receivedDateTo")   ? obj.get("receivedDateTo").getAsString()   : "");
-        if (!receivedDateFrom.isEmpty() && !receivedDateTo.isEmpty()) {
-            whereClause.append(" AND DATE(rec.approvedDate) BETWEEN ? AND ? ");
-            params.add(receivedDateFrom); params.add(receivedDateTo);
-        } else if (!receivedDateFrom.isEmpty()) {
-            whereClause.append(" AND DATE(rec.approvedDate) >= ? ");
-            params.add(receivedDateFrom);
-        } else if (!receivedDateTo.isEmpty()) {
-            whereClause.append(" AND DATE(rec.approvedDate) <= ? ");
-            params.add(receivedDateTo);
-        }
-
-        String isdFrom = convertToSqlDate(obj.has("isdFrom") ? obj.get("isdFrom").getAsString() : "");
-        String isdTo   = convertToSqlDate(obj.has("isdTo")   ? obj.get("isdTo").getAsString()   : "");
-        if (!isdFrom.isEmpty() && !isdTo.isEmpty()) {
-            whereClause.append(" AND DATE(LN2.dateInService) BETWEEN ? AND ? ");
-            params.add(isdFrom); params.add(isdTo);
-        } else if (!isdFrom.isEmpty()) {
-            whereClause.append(" AND DATE(LN2.dateInService) >= ? ");
-            params.add(isdFrom);
-        } else if (!isdTo.isEmpty()) {
-            whereClause.append(" AND DATE(LN2.dateInService) <= ? ");
-            params.add(isdTo);
-        }
-
-        String baseSql = " FROM tb_DCC DCC "
-                + "JOIN tb_PurchaseOrder HD ON DCC.poNumber = HD.poNumber "
-                + "JOIN ( "
-                + "    SELECT t.acceptanceRequestRecordNo, MAX(t.recordNo) AS recordNo "
-                + "    FROM tb_Category_Approval_Requests t "
-                + "    WHERE t.status = 'approved' AND t.received = 1 "
-                + "    GROUP BY t.acceptanceRequestRecordNo "
-                + ") AR_latest ON DCC.recordNo = AR_latest.acceptanceRequestRecordNo "
-                + "JOIN tb_Category_Approval_Requests AR ON AR.recordNo = AR_latest.recordNo "
-                + "LEFT JOIN ( "
-                + "    SELECT r.categoryApprovalRequestId, MAX(r.approvedDate) AS approvedDate "
-                + "    FROM tb_AcceptanceRequest_Receipt r "
-                + "    WHERE r.approvalStatus = 'received' "
-                + "    GROUP BY r.categoryApprovalRequestId "
-                + ") rec ON AR.recordNo = rec.categoryApprovalRequestId "
-                + "JOIN tb_DCC_LN LN2 ON DCC.recordNo = LN2.dccId "
-                + "LEFT JOIN tb_PurchaseOrderUPL upl ON DCC.poNumber = upl.poNumber AND LN2.uplLineNumber = upl.uplLine AND upl.poLineNumber = LN2.lineNumber "
-                + "LEFT JOIN tb_Site site ON LN2.locationName COLLATE utf8mb4_general_ci = site.siteId COLLATE utf8mb4_general_ci "
-                + "LEFT JOIN tb_Site_Type siteType ON site.siteTypeId COLLATE utf8mb4_general_ci = siteType.recordNo COLLATE utf8mb4_general_ci "
-                + "LEFT JOIN tb_Region rg ON site.regionId COLLATE utf8mb4_general_ci = rg.recordNo COLLATE utf8mb4_general_ci "
-                + "WHERE (0 <> (CASE WHEN LENGTH(LN2.uplLineNumber) > 0 "
-                + "  THEN (LN2.uplLineNumber = upl.uplLine AND upl.poLineNumber = LN2.lineNumber AND upl.poNumber = DCC.poNumber) "
-                + "  ELSE (HD.lineNumber = LN2.lineNumber AND HD.poNumber = DCC.poNumber) END)) "
-                + "AND DCC.status = 'approved-received' "
-                + whereClause;
-
-        String sql = "SELECT "
-                + "DCC.recordNo AS requestNo, "
-                + "DCC.poNumber AS poNumber, "
-                + "LN2.lineNumber AS poLineNumber, "
-                + "LN2.uplLineNumber AS uplLineNumber, "
-                + "LN2.locationName AS siteId, "
-                + "LN2.linkId AS linkId, "
-                + "LN2.dateInService AS isd, "
-                + "rg.regionName AS region, "
-                + "siteType.siteTypeName AS siteTypeName, "
-                + "(CASE WHEN HD.newProjectName IS NULL OR LENGTH(TRIM(HD.newProjectName)) = 0 THEN HD.projectName ELSE HD.newProjectName END) AS projectName, "
-                + "(CASE WHEN LENGTH(LN2.uplLineNumber) > 0 THEN upl.uplLineDescription ELSE HD.poLineDescription END) AS description, "
-                + "LN2.deliveredQty AS quantity, "
-                + "(CASE WHEN LENGTH(LN2.uplLineNumber) > 0 THEN (CASE WHEN LENGTH(LN2.actualItemCode) > 0 THEN LN2.actualItemCode ELSE upl.uplLineItemCode END) ELSE HD.itemPartNumber END) AS partNumber, "
-                + "(CASE WHEN UPPER(TRIM(upl.uplItemSerialized)) IN ('YES','Y','TRUE','1') THEN 'YES' "
-                + "WHEN UPPER(TRIM(upl.uplItemSerialized)) IN ('NO','N','FALSE','0') THEN 'NO' ELSE NULL END) AS itemSerializedStatus, "
-                + "LN2.serialNumber AS serialNumber, "
-                + "upl.zainItemCategoryDescription AS uplItemCategoryCodeDescription, "
-                + "(upl.uplLineUnitPrice * LN2.deliveredQty) AS faBookingAmount, "
-                + "'SAR' AS currency, "
-                + "LN2.tagNumber AS tagNumber, "
-                + "rec.approvedDate AS receiveddate "
-                + baseSql
-                + " GROUP BY LN2.recordNo";
-
-        List<String> columns = Arrays.asList(
-                "sequenceNo", "requestNo", "poNumber", "poLineNumber", "uplLineNumber",
-                "siteId", "linkId", "isd", "region", "siteTypeName", "projectName",
-                "description", "quantity", "partNumber", "itemSerializedStatus",
-                "serialNumber", "uplItemCategoryCodeDescription", "faBookingAmount",
-                "currency", "tagNumber", "receiveddate"
-        );
-
-        List<String> headerNames = Arrays.asList(
-                "Sequence No", "Request No", "PO Number", "PO Line", "UPL Line",
-                "Site ID", "Link ID", "ISD", "Region", "Site Type", "Project Name",
-                "Description", "Quantity", "Part Number", "Item Serialized [Yes/No]",
-                "Serial Number", "Category Description", "FA Booking Amount",
-                "PO Currency", "TAG Number", "Received Date"
-        );
-
-        response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        response.setHeader("Content-Disposition", "attachment; filename=capitalization_report.xlsx");
-
-        try {
-            jdbcTemplate.execute("SET SESSION sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''))");
-        } catch (Exception ignore) {}
-
-        SXSSFWorkbook workbook = new SXSSFWorkbook(500);
-        try (Connection conn = dataSource.getConnection()) {
-            try { conn.setAutoCommit(false); } catch (Exception ignore) {}
-
-            try (PreparedStatement ps = conn.prepareStatement(sql,
-                    ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)) {
-                try { ps.setFetchSize(DEFAULT_FETCH_SIZE); } catch (Exception ignore) {}
-
-                int idx = 1;
-                for (Object p : params) ps.setObject(idx++, p);
-
-                Sheet sheet = workbook.createSheet("Capitalization Report");
-                Row header = sheet.createRow(0);
-                for (int i = 0; i < headerNames.size(); i++) {
-                    header.createCell(i).setCellValue(headerNames.get(i));
-                }
-
-                CellStyle dateCellStyle = workbook.createCellStyle();
-                CreationHelper createHelper = workbook.getCreationHelper();
-                dateCellStyle.setDataFormat(createHelper.createDataFormat().getFormat("dd-mmm-yyyy"));
-                dateCellStyle.setAlignment(HorizontalAlignment.CENTER);
-
-                AtomicInteger rowIdx     = new AtomicInteger(1);
-                AtomicInteger sequenceNo = new AtomicInteger(1);
-
-                try (ResultSet rs = ps.executeQuery()) {
-                    ResultSetMetaData rsMd = rs.getMetaData();
-                    Set<String> rsColsLower = new HashSet<>();
-                    for (int i = 1; i <= rsMd.getColumnCount(); i++) {
-                        String label = rsMd.getColumnLabel(i);
-                        if (label != null) rsColsLower.add(label.toLowerCase(Locale.ROOT));
-                    }
-
-                    while (rs.next()) {
-                        Row row = sheet.createRow(rowIdx.getAndIncrement());
-                        for (int i = 0; i < columns.size(); i++) {
-                            String colName = columns.get(i);
-                            Cell cell = row.createCell(i);
-                            if ("sequenceNo".equals(colName)) {
-                                cell.setCellValue(sequenceNo.getAndIncrement());
-                            } else if ("receiveddate".equals(colName) || "isd".equals(colName)) {
-                                Timestamp ts = null;
-                                try { ts = rs.getTimestamp(colName); } catch (SQLException ignored) {}
-                                if (ts != null) {
-                                    cell.setCellType(CellType.NUMERIC);
-                                    cell.setCellValue(new java.util.Date(ts.getTime()));
-                                    cell.setCellStyle(dateCellStyle);
-                                } else {
-                                    cell.setBlank();
-                                }
-                            } else {
-                                String val = null;
-                                try { val = rs.getString(colName); } catch (SQLException ex) {}
-                                cell.setCellValue(val == null ? "" : val);
-                            }
-                        }
-                    }
-                }
-
-                try (BufferedOutputStream bos = new BufferedOutputStream(
-                        response.getOutputStream(), 128 * 1024)) {
-                    workbook.write(bos);
-                    bos.flush();
-                }
-                response.flushBuffer();
-            }
-
-        } catch (Exception e) {
-            if (!response.isCommitted()) {
-                response.reset();
-                response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-                response.setContentType("text/plain");
-                response.getWriter().write("Excel export failed: " + e.getMessage());
-                response.getWriter().flush();
-            }
-        } finally {
-            workbook.dispose();
         }
     }
 
+    StringBuilder whereClause = new StringBuilder();
+    List<Object> params = new ArrayList<>();
+
+    // FIX: handle poNumber with the same exact-match + "0" guard as the fetch endpoint
+    String poNumber = obj.has("poNumber") ? obj.get("poNumber").getAsString() : "0";
+    if (!poNumber.equalsIgnoreCase("0") && !poNumber.isEmpty()) {
+        whereClause.append(" AND DCC.poNumber = ?");
+        params.add(poNumber);
+    }
+
+    for (Map.Entry<String, JsonElement> entry : filtersObj.entrySet()) {
+        String columnKey = entry.getKey();
+        if (!searchableColumns.containsKey(columnKey)) continue;
+        String rawValue = entry.getValue().getAsString();
+        if (rawValue == null) continue;
+        rawValue = rawValue.trim();
+        if (rawValue.isEmpty()) continue;
+
+        String sqlCol = searchableColumns.get(columnKey);
+        if ("receiveddate".equals(columnKey) || "isd".equals(columnKey)) continue;
+
+        if (rawValue.contains(",")) {
+            String[] tokens = Arrays.stream(rawValue.split(","))
+                    .map(String::trim).filter(s -> !s.isEmpty()).toArray(String[]::new);
+            if (tokens.length == 0) continue;
+            if (numericColumns.contains(columnKey)) {
+                whereClause.append(" AND ").append(sqlCol).append(" IN (")
+                        .append(String.join(",", Collections.nCopies(tokens.length, "?"))).append(") ");
+                for (String t : tokens) params.add(t);
+            } else {
+                whereClause.append(" AND (");
+                for (int i = 0; i < tokens.length; i++) {
+                    if (i > 0) whereClause.append(" OR ");
+                    whereClause.append("LOWER(").append(sqlCol).append(") LIKE LOWER(?)");
+                    params.add("%" + tokens[i] + "%");
+                }
+                whereClause.append(") ");
+            }
+        } else {
+            if (numericColumns.contains(columnKey)) {
+                whereClause.append(" AND ").append(sqlCol).append(" = ? ");
+                params.add(rawValue);
+            } else {
+                whereClause.append(" AND LOWER(").append(sqlCol).append(") LIKE LOWER(?) ");
+                params.add("%" + rawValue + "%");
+            }
+        }
+    }
+    String receivedDateFrom = convertToSqlDate(obj.has("receivedDateFrom") ? obj.get("receivedDateFrom").getAsString() : "");
+    String receivedDateTo   = convertToSqlDate(obj.has("receivedDateTo")   ? obj.get("receivedDateTo").getAsString()   : "");
+    if (!receivedDateFrom.isEmpty() && !receivedDateTo.isEmpty()) {
+        whereClause.append(" AND DATE(rec.approvedDate) BETWEEN ? AND ? ");
+        params.add(receivedDateFrom); params.add(receivedDateTo);
+    } else if (!receivedDateFrom.isEmpty()) {
+        whereClause.append(" AND DATE(rec.approvedDate) >= ? ");
+        params.add(receivedDateFrom);
+    } else if (!receivedDateTo.isEmpty()) {
+        whereClause.append(" AND DATE(rec.approvedDate) <= ? ");
+        params.add(receivedDateTo);
+    }
+
+    String isdFrom = convertToSqlDate(obj.has("isdFrom") ? obj.get("isdFrom").getAsString() : "");
+    String isdTo   = convertToSqlDate(obj.has("isdTo")   ? obj.get("isdTo").getAsString()   : "");
+    if (!isdFrom.isEmpty() && !isdTo.isEmpty()) {
+        whereClause.append(" AND DATE(LN2.dateInService) BETWEEN ? AND ? ");
+        params.add(isdFrom); params.add(isdTo);
+    } else if (!isdFrom.isEmpty()) {
+        whereClause.append(" AND DATE(LN2.dateInService) >= ? ");
+        params.add(isdFrom);
+    } else if (!isdTo.isEmpty()) {
+        whereClause.append(" AND DATE(LN2.dateInService) <= ? ");
+        params.add(isdTo);
+    }
+
+    String baseSql = " FROM tb_DCC DCC "
+            + "JOIN tb_PurchaseOrder HD ON DCC.poNumber = HD.poNumber "
+            + "JOIN ( "
+            + "    SELECT t.acceptanceRequestRecordNo, MAX(t.recordNo) AS recordNo "
+            + "    FROM tb_Category_Approval_Requests t "
+            + "    WHERE t.status = 'approved' AND t.received = 1 "
+            + "    GROUP BY t.acceptanceRequestRecordNo "
+            + ") AR_latest ON DCC.recordNo = AR_latest.acceptanceRequestRecordNo "
+            + "JOIN tb_Category_Approval_Requests AR ON AR.recordNo = AR_latest.recordNo "
+            + "LEFT JOIN ( "
+            + "    SELECT r.categoryApprovalRequestId, MAX(r.approvedDate) AS approvedDate "
+            + "    FROM tb_AcceptanceRequest_Receipt r "
+            + "    WHERE r.approvalStatus = 'received' "
+            + "    GROUP BY r.categoryApprovalRequestId "
+            + ") rec ON AR.recordNo = rec.categoryApprovalRequestId "
+            + "JOIN tb_DCC_LN LN2 ON DCC.recordNo = LN2.dccId "
+            + "LEFT JOIN tb_PurchaseOrderUPL upl ON DCC.poNumber = upl.poNumber AND LN2.uplLineNumber = upl.uplLine AND upl.poLineNumber = LN2.lineNumber "
+            + "LEFT JOIN tb_Site site ON LN2.locationName COLLATE utf8mb4_general_ci = site.siteId COLLATE utf8mb4_general_ci "
+            + "LEFT JOIN tb_Site_Type siteType ON site.siteTypeId COLLATE utf8mb4_general_ci = siteType.recordNo COLLATE utf8mb4_general_ci "
+            + "LEFT JOIN tb_Region rg ON site.regionId COLLATE utf8mb4_general_ci = rg.recordNo COLLATE utf8mb4_general_ci "
+            + "WHERE (0 <> (CASE WHEN LENGTH(LN2.uplLineNumber) > 0 "
+            + "  THEN (LN2.uplLineNumber = upl.uplLine AND upl.poLineNumber = LN2.lineNumber AND upl.poNumber = DCC.poNumber) "
+            + "  ELSE (HD.lineNumber = LN2.lineNumber AND HD.poNumber = DCC.poNumber) END)) "
+            + "AND DCC.status = 'approved-received' "
+            + whereClause;
+
+    String sql = "SELECT "
+            + "DCC.recordNo AS requestNo, "
+            + "DCC.poNumber AS poNumber, "
+            + "LN2.lineNumber AS poLineNumber, "
+            + "LN2.uplLineNumber AS uplLineNumber, "
+            + "LN2.locationName AS siteId, "
+            + "LN2.linkId AS linkId, "
+            + "LN2.dateInService AS isd, "
+            + "rg.regionName AS region, "
+            + "siteType.siteTypeName AS siteTypeName, "
+            + "(CASE WHEN HD.newProjectName IS NULL OR LENGTH(TRIM(HD.newProjectName)) = 0 THEN HD.projectName ELSE HD.newProjectName END) AS projectName, "
+            + "(CASE WHEN LENGTH(LN2.uplLineNumber) > 0 THEN upl.uplLineDescription ELSE HD.poLineDescription END) AS description, "
+            + "LN2.deliveredQty AS quantity, "
+            + "(CASE WHEN LENGTH(LN2.uplLineNumber) > 0 THEN (CASE WHEN LENGTH(LN2.actualItemCode) > 0 THEN LN2.actualItemCode ELSE upl.uplLineItemCode END) ELSE HD.itemPartNumber END) AS partNumber, "
+            + "(CASE WHEN UPPER(TRIM(upl.uplItemSerialized)) IN ('YES','Y','TRUE','1') THEN 'YES' "
+            + "WHEN UPPER(TRIM(upl.uplItemSerialized)) IN ('NO','N','FALSE','0') THEN 'NO' ELSE NULL END) AS itemSerializedStatus, "
+            + "LN2.serialNumber AS serialNumber, "
+            + "upl.zainItemCategoryDescription AS uplItemCategoryCodeDescription, "
+            + "(upl.uplLineUnitPrice * LN2.deliveredQty) AS faBookingAmount, "
+            + "'SAR' AS currency, "
+            + "LN2.tagNumber AS tagNumber, "
+            + "rec.approvedDate AS receiveddate "
+            + baseSql
+            + " GROUP BY LN2.recordNo";
+
+    List<String> columns = Arrays.asList(
+            "sequenceNo", "requestNo", "poNumber", "poLineNumber", "uplLineNumber",
+            "siteId", "linkId", "isd", "region", "siteTypeName", "projectName",
+            "description", "quantity", "partNumber", "itemSerializedStatus",
+            "serialNumber", "uplItemCategoryCodeDescription", "faBookingAmount",
+            "currency", "tagNumber", "receiveddate"
+    );
+
+    List<String> headerNames = Arrays.asList(
+            "Sequence No", "Request No", "PO Number", "PO Line", "UPL Line",
+            "Site ID", "Link ID", "ISD", "Region", "Site Type", "Project Name",
+            "Description", "Quantity", "Part Number", "Item Serialized [Yes/No]",
+            "Serial Number", "Category Description", "FA Booking Amount",
+            "PO Currency", "TAG Number", "Received Date"
+    );
+
+    response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+    response.setHeader("Content-Disposition", "attachment; filename=capitalization_report.xlsx");
+
+    try {
+        jdbcTemplate.execute("SET SESSION sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''))");
+    } catch (Exception ignore) {}
+
+    SXSSFWorkbook workbook = new SXSSFWorkbook(500);
+    try (Connection conn = dataSource.getConnection()) {
+        try { conn.setAutoCommit(false); } catch (Exception ignore) {}
+
+        try (PreparedStatement ps = conn.prepareStatement(sql,
+                ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)) {
+            try { ps.setFetchSize(DEFAULT_FETCH_SIZE); } catch (Exception ignore) {}
+
+            int idx = 1;
+            for (Object p : params) ps.setObject(idx++, p);
+
+            Sheet sheet = workbook.createSheet("Capitalization Report");
+            Row header = sheet.createRow(0);
+            for (int i = 0; i < headerNames.size(); i++) {
+                header.createCell(i).setCellValue(headerNames.get(i));
+            }
+
+            CellStyle dateCellStyle = workbook.createCellStyle();
+            CreationHelper createHelper = workbook.getCreationHelper();
+            dateCellStyle.setDataFormat(createHelper.createDataFormat().getFormat("dd-mmm-yyyy"));
+            dateCellStyle.setAlignment(HorizontalAlignment.CENTER);
+
+            AtomicInteger rowIdx     = new AtomicInteger(1);
+            AtomicInteger sequenceNo = new AtomicInteger(1);
+
+            try (ResultSet rs = ps.executeQuery()) {
+                ResultSetMetaData rsMd = rs.getMetaData();
+                Set<String> rsColsLower = new HashSet<>();
+                for (int i = 1; i <= rsMd.getColumnCount(); i++) {
+                    String label = rsMd.getColumnLabel(i);
+                    if (label != null) rsColsLower.add(label.toLowerCase(Locale.ROOT));
+                }
+
+                while (rs.next()) {
+                    Row row = sheet.createRow(rowIdx.getAndIncrement());
+                    for (int i = 0; i < columns.size(); i++) {
+                        String colName = columns.get(i);
+                        Cell cell = row.createCell(i);
+                        if ("sequenceNo".equals(colName)) {
+                            cell.setCellValue(sequenceNo.getAndIncrement());
+                        } else if ("receiveddate".equals(colName) || "isd".equals(colName)) {
+                            Timestamp ts = null;
+                            try { ts = rs.getTimestamp(colName); } catch (SQLException ignored) {}
+                            if (ts != null) {
+                                cell.setCellType(CellType.NUMERIC);
+                                cell.setCellValue(new java.util.Date(ts.getTime()));
+                                cell.setCellStyle(dateCellStyle);
+                            } else {
+                                cell.setBlank();
+                            }
+                        } else {
+                            String val = null;
+                            try { val = rs.getString(colName); } catch (SQLException ex) {}
+                            cell.setCellValue(val == null ? "" : val);
+                        }
+                    }
+                }
+            }
+
+            try (BufferedOutputStream bos = new BufferedOutputStream(
+                    response.getOutputStream(), 128 * 1024)) {
+                workbook.write(bos);
+                bos.flush();
+            }
+            response.flushBuffer();
+        }
+
+    } catch (Exception e) {
+        if (!response.isCommitted()) {
+            response.reset();
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            response.setContentType("text/plain");
+            response.getWriter().write("Excel export failed: " + e.getMessage());
+            response.getWriter().flush();
+        }
+    } finally {
+        workbook.dispose();
+    }
+}
     // ============================================================================
     // Item Code Substitutes Export
     // ============================================================================


### PR DESCRIPTION
Problem

Capitalization report export and fetch endpoints were out of sync — fetch returned 49,718 rows while export returned 49,570 rows (148 missing rows).

Root Cause

The frontend sends poNumber: "0" in the export request body to indicate "no filter (return all records)".

However, in the export implementation:

The generic filtersObj loop did not exclude poNumber
This caused an unintended filter to be applied:
AND LOWER(DCC.poNumber) LIKE LOWER('%0%')

As a result:

Any record whose PO number did not contain the digit "0" was excluded
This led to 148 missing rows in the export

Meanwhile:

The fetch endpoint was not affected
It correctly handles poNumber separately using an equalsIgnoreCase("0") guard