### PR TITLE
Fix vendor filter leakage when applying additional grid filters

### DIFF
--- a/src/main/java/com/zain/almksazain/controller/AgingReportController.java
+++ b/src/main/java/com/zain/almksazain/controller/AgingReportController.java
@@ -1,6 +1,7 @@
 package com.zain.almksazain.controller;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -36,74 +37,81 @@ public class AgingReportController {
         return agingReportService.getGroupedAgingReport(request);
     }
 
-   @PostMapping(value = "/reports/v2/agingReport", produces = "application/json")
-    @CrossOrigin(origins = "*", allowedHeaders = "*", maxAge = 3600)
-    public ResponseEntity<?> getAgingReports(@RequestBody String req) {
-        logger.info("Received request for agingReport: {}", req);
+@PostMapping(value = "/reports/v2/agingReport", produces = "application/json")
+@CrossOrigin(origins = "*", allowedHeaders = "*", maxAge = 3600)
+public ResponseEntity<?> getAgingReports(@RequestBody String req) {
+    logger.info("Received request for agingReport: {}", req);
 
-        JsonObject obj;
-        try {
-            obj = JsonParser.parseString(req).getAsJsonObject();
-        } catch (Exception e) {
-            logger.warn("Invalid JSON request body", e);
-            return ResponseEntity.badRequest().body(Map.of("error", "Invalid JSON"));
-        }
+    JsonObject obj;
+    try {
+        obj = JsonParser.parseString(req).getAsJsonObject();
+    } catch (Exception e) {
+        logger.warn("Invalid JSON request body", e);
+        return ResponseEntity.badRequest().body(Map.of("error", "Invalid JSON"));
+    }
 
-        // Safe extraction of fields (guards against missing keys / null values)
-        String supplierId = (obj.has("supplierId") && !obj.get("supplierId").isJsonNull())
-                ? obj.get("supplierId").getAsString() : null;
-        String columnName = (obj.has("columnName") && !obj.get("columnName").isJsonNull())
-                ? obj.get("columnName").getAsString() : "";
+    // Safe extraction of fields (guards against missing keys / null values)
+    String supplierId = (obj.has("supplierId") && !obj.get("supplierId").isJsonNull())
+            ? obj.get("supplierId").getAsString() : null;
+    int page = (obj.has("page") && !obj.get("page").isJsonNull()) ? obj.get("page").getAsInt() : 1;
+    int size = (obj.has("size") && !obj.get("size").isJsonNull()) ? obj.get("size").getAsInt() : 100;
+
+    // Extract filters - support both old format (columnName/searchQuery) and new format (filterBy object)
+    Map<String, String> filters = new HashMap<>();
+
+    // Legacy format: single columnName + searchQuery
+    if (obj.has("columnName") && !obj.get("columnName").isJsonNull() && !obj.get("columnName").getAsString().isEmpty()) {
+        String columnName = obj.get("columnName").getAsString();
         String searchQuery = (obj.has("searchQuery") && !obj.get("searchQuery").isJsonNull())
                 ? obj.get("searchQuery").getAsString() : "";
-        int page = (obj.has("page") && !obj.get("page").isJsonNull()) ? obj.get("page").getAsInt() : 0;
-        int size = (obj.has("size") && !obj.get("size").isJsonNull()) ? obj.get("size").getAsInt() : 100;
-
-        logger.debug("Parsed params - supplierId: {}, columnName: {}, searchQuery: {}, page: {}, size: {}",
-                supplierId, columnName, searchQuery, page, size);
-
-        Map<String, Object> response = dccPoCombinedService.getAgingReport(supplierId, columnName, searchQuery, page, size);
-
-        // Compute data size safely (response.get("data") might be null or not a Collection)
-        int dataCount = 0;
-        Object dataObj = response.get("data");
-        if (dataObj instanceof Collection) {
-            dataCount = ((Collection<?>) dataObj).size();
-        } else if (dataObj instanceof Iterable) {
-            // fallback for iterable: attempt to iterate for count (not ideal for very large results)
-            int cnt = 0;
-            for (Object ignored : (Iterable<?>) dataObj) cnt++;
-            dataCount = cnt;
+        if (!searchQuery.isEmpty()) {
+            filters.put(columnName, searchQuery);
+            logger.debug("Legacy filter format - columnName: {}, searchQuery: {}", columnName, searchQuery);
         }
-
-        logger.info("Returning aging report response with {} records (page {}/{})",
-                dataCount,
-                response.get("currentPage"),
-                response.get("totalPages"));
-
-        return ResponseEntity.ok(response);
     }
-    
-    // New multiple filter endpoint
-@PostMapping("/reports/v2/agingReport/filter")
-public ResponseEntity<Map<String, Object>> getAgingReportWithMultipleFilters(
-        @RequestParam(required = false) String supplierId,
-        @RequestBody Map<String, String> filters, 
-        @RequestParam(defaultValue = "1") int page,
-        @RequestParam(defaultValue = "100") int size) {
-    
-    
-    // Clean and validate filters
-    Map<String, String> cleanedFilters = filters.entrySet().stream()
-            .filter(entry -> entry.getValue() != null && !entry.getValue().trim().isEmpty())
-            .collect(Collectors.toMap(
-                Map.Entry::getKey,
-                entry -> entry.getValue().trim()
-            ));
-    
-    Map<String, Object> result = dccPoCombinedService.getAgingReportWithMultipleFilters(
-        supplierId, cleanedFilters, page, size);
-    return ResponseEntity.ok(result);
-}
 
+    // New format: filterBy object with multiple filters
+    if (obj.has("filterBy") && obj.get("filterBy").isJsonObject()) {
+        JsonObject filterByObj = obj.get("filterBy").getAsJsonObject();
+        for (String key : filterByObj.keySet()) {
+            if (!filterByObj.get(key).isJsonNull()) {
+                String value = filterByObj.get(key).getAsString().trim();
+                if (!value.isEmpty()) {
+                    filters.put(key, value);
+                    logger.debug("Filter from filterBy - {}: {}", key, value);
+                }
+            }
+        }
+    }
+
+    logger.debug("Parsed params - supplierId: {}, page: {}, size: {}, total filters: {}",
+            supplierId, page, size, filters.size());
+
+    // Use multi-filter method if filters exist, otherwise use single-filter method
+    Map<String, Object> response;
+    if (!filters.isEmpty()) {
+        response = dccPoCombinedService.getAgingReportWithMultipleFilters(supplierId, filters, page, size);
+    } else {
+        response = dccPoCombinedService.getAgingReport(supplierId, "", "", page, size);
+    }
+
+    int dataCount = 0;
+    Object dataObj = response.get("data");
+    if (dataObj instanceof Collection) {
+        dataCount = ((Collection<?>) dataObj).size();
+    } else if (dataObj instanceof Iterable) {
+        int cnt = 0;
+        for (Object ignored : (Iterable<?>) dataObj) cnt++;
+        dataCount = cnt;
+    }
+
+    logger.info("Returning aging report response with {} records (page {}/{})",
+            dataCount,
+            response.get("currentPage"),
+            response.get("totalPages"));
+
+    return ResponseEntity.ok(response);
+}
+    
+   
 }

--- a/src/main/java/com/zain/almksazain/services/DccPoCombinedService.java
+++ b/src/main/java/com/zain/almksazain/services/DccPoCombinedService.java
@@ -715,21 +715,21 @@ public Map<String, Object> getAgingReportWithMultipleFilters(
     
     final String onlyStatus = "inprocess";
 
-    if (hasFilters) {
-        Pageable unpaged = Pageable.unpaged();
-        pagedDcc = (supplierId != null && !"0".equals(supplierId))
-                ? dccRepository.findAllBySupplierIdAndStatus(supplierId, onlyStatus, unpaged)
-                : dccRepository.findAllByStatus(onlyStatus, unpaged);
-        dccList = pagedDcc.getContent();
-        System.out.println("Loaded " + dccList.size() + " DCC records for filtering");
-    } else {
-        Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "recordNo"));
-        pagedDcc = (supplierId != null && !"0".equals(supplierId))
-                ? dccRepository.findAllBySupplierIdAndStatus(supplierId, onlyStatus, pageable)
-                : dccRepository.findAllByStatus(onlyStatus, pageable);
-        dccList = pagedDcc.getContent();
-        System.out.println("Loaded " + dccList.size() + " DCC records with pagination");
-    }
+if (hasFilters) {
+    Pageable unpaged = Pageable.unpaged();
+    pagedDcc = (supplierId != null && !"0".equals(supplierId.trim()))
+            ? dccRepository.findAllBySupplierVendorAndStatus(supplierId, onlyStatus, unpaged)
+            : dccRepository.findAllByStatus(onlyStatus, unpaged);
+    dccList = pagedDcc.getContent();
+    System.out.println("Loaded " + dccList.size() + " DCC records for filtering");
+} else {
+    Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "recordNo"));
+    pagedDcc = (supplierId != null && !"0".equals(supplierId.trim()))
+            ? dccRepository.findAllBySupplierVendorAndStatus(supplierId, onlyStatus, pageable)
+            : dccRepository.findAllByStatus(onlyStatus, pageable);
+    dccList = pagedDcc.getContent();
+    System.out.println("Loaded " + dccList.size() + " DCC records with pagination");
+}
     
     if (dccList.isEmpty()) {
         Map<String, Object> emptyResponse = new HashMap<>();
@@ -830,7 +830,7 @@ private boolean matchesFilter(Map<String, Object> row, String columnName, String
         return true;
     }
     
-    ColumnInfo mapping = COLUMN_MAPPINGS.get(columnName);
+    ColumnInfo mapping = getColumnInfoInsensitive(columnName);
     String targetKey = (mapping != null && mapping.getFieldName() != null && !mapping.getFieldName().trim().isEmpty())
             ? mapping.getFieldName()
             : columnName;
@@ -886,5 +886,14 @@ private boolean matchesFilter(Map<String, Object> row, String columnName, String
     return containsMatch;
 }
 
-
+// case-insensitive lookup helper
+private ColumnInfo getColumnInfoInsensitive(String key) {
+    if (key == null) return null;
+    ColumnInfo info = COLUMN_MAPPINGS.get(key);
+    if (info != null) return info;
+    for (Map.Entry<String, ColumnInfo> e : COLUMN_MAPPINGS.entrySet()) {
+        if (e.getKey().equalsIgnoreCase(key)) return e.getValue();
+    }
+    return null;
+}
 }


### PR DESCRIPTION
 Summary

Fixes an issue where vendor-specific filtering was not preserved when applying additional grid or multi-filters.

 Problem
Initial filtering by a specific vendor returned correct results
However, applying additional filters caused data from other vendors to appear
This resulted in inconsistent and incorrect datasets being displayed
Grid filtering and multi-filter logic were not aligned, causing vendor filter conditions to be lost or overridden
 Fix
Ensured vendor filter condition is consistently applied across all filter operations
Aligned grid and multi-filter logic to use the same filtering behavior

